### PR TITLE
docs: clarify instructions for running a mainnet node

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,14 +35,7 @@ Building NanoReth from source requires Rust and Cargo to be installed:
     You can now restart NanoReth using the same command as above:
 
     ```sh
-    # Fetch EVM blocks
-    $ aws s3 sync s3://hl-mainnet-evm-blocks/ ~/evm-blocks --request-payer requester # one-time
-    $ goofys --region=ap-northeast-1 --requester-pays hl-mainnet-evm-blocks evm-blocks # realtime
-
-    # Run node
-    $ make install
-    $ reth node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 \
-        --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --ws.port 8545
+    $ reth node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --ws.port 8545
     ```
 
 ## How to run (testnet)

--- a/README.md
+++ b/README.md
@@ -8,18 +8,42 @@ Deposit transactions from `0x222..22` to user addresses are intentionally record
 This change simplifies block explorers, making it easier to track deposit timestamps.
 Ensure careful handling when indexing.
 
+## Prerequisites
+
+Building NanoReth from source requires Rust and Cargo to be installed:
+
+`$ curl https://sh.rustup.rs -sSf | sh`
+
 ## How to run (mainnet)
 
-```sh
-# Fetch EVM blocks
-$ aws s3 sync s3://hl-mainnet-evm-blocks/ ~/evm-blocks --request-payer requester # one-time
-$ goofys --region=ap-northeast-1 --requester-pays hl-mainnet-evm-blocks evm-blocks-bak # realtime
+1) `$ aws s3 sync s3://hl-mainnet-evm-blocks/ ~/evm-blocks --request-payer requester # one-time` - this will backfill the existing blocks from HyperLiquid's EVM S3 bucket.
 
-# Run node
-$ make install
-$ reth node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 \
-    --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --ws.port 8545
-```
+2) `$ make install` - this will install the NanoReth binary.
+
+3) Start NanoReth which will begin syncing using the blocks in `~/evm-blocks`:
+
+    ```sh
+    $ reth node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --ws.port 8545
+    ```
+
+4) Once the node logs stops making progress this means it's caught up with the existing blocks.
+
+    Stop the NanoReth process and then start Goofys: `$ goofys --region=ap-northeast-1 --requester-pays hl-mainnet-evm-blocks evm-blocks`
+
+    Goofys will mount the AWS S3 bucket into `~/evm-blocks` and save new blocks as they are added to the bucket.
+
+    You can now restart NanoReth using the same command as above:
+
+    ```sh
+    # Fetch EVM blocks
+    $ aws s3 sync s3://hl-mainnet-evm-blocks/ ~/evm-blocks --request-payer requester # one-time
+    $ goofys --region=ap-northeast-1 --requester-pays hl-mainnet-evm-blocks evm-blocks # realtime
+
+    # Run node
+    $ make install
+    $ reth node --http --http.addr 0.0.0.0 --http.api eth,ots,net,web3 \
+        --ws --ws.addr 0.0.0.0 --ws.origins '*' --ws.api eth,ots,net,web3 --ingest-dir ~/evm-blocks --ws.port 8545
+    ```
 
 ## How to run (testnet)
 


### PR DESCRIPTION
Added info about prerequisites (Rust/Cargo installed) and more detailed instructions on the steps to run a mainnet node.