### PR TITLE
chore(rpc): only forward calls to upstream if against latest block state

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,11 @@ fn main() -> eyre::Result<()> {
 
                 if ext.forward_call {
                     ctx.modules.replace_configured(
-                        call_forwarder::CallForwarderExt::new(upstream_rpc_url.clone()).into_rpc(),
+                        call_forwarder::CallForwarderExt::new(
+                            upstream_rpc_url.clone(),
+                            ctx.registry.eth_api().clone(),
+                        )
+                        .into_rpc(),
                     )?;
                     info!("Call/gas estimation will be forwarded to {}", upstream_rpc_url);
                 }


### PR DESCRIPTION
Previously, when running with the `--forward-call` flag, `eth_call` and `eth_estimateGas` were forwarded to upstream regardless of the specified block parameter. According to [HyperEVM JSON-RPC documentation](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/hyperevm/json-rpc), these methods only support execution against the "latest" block.

When users specified a historical block number, calls were still forwarded to upstream which executed against latest state, returning incorrect responses.

## Changes:
- Only forward `eth_call` and `eth_estimateGas` when block parameter is "latest"
- Historical block calls now execute locally to ensure accurate state

## Note:
Historical calls involving precompiles will now return errors since local execution doesn't support precompiles