### PR TITLE
feat: Add --local.fallback-threshold, --s3.polling-interval

### DIFF
--- a/src/pseudo_peer/config.rs
+++ b/src/pseudo_peer/config.rs
@@ -1,31 +1,38 @@
 use crate::chainspec::HlChainSpec;
 
 use super::sources::{
-    BlockSourceBoxed, CachedBlockSource, HlNodeBlockSource, LocalBlockSource, S3BlockSource,
+    BlockSourceBoxed, CachedBlockSource, HlNodeBlockSource, HlNodeBlockSourceArgs,
+    LocalBlockSource, S3BlockSource,
 };
 use aws_config::BehaviorVersion;
-use std::{env::home_dir, path::PathBuf, sync::Arc};
+use std::{env::home_dir, path::PathBuf, sync::Arc, time::Duration};
 
 #[derive(Debug, Clone)]
 pub struct BlockSourceConfig {
     pub source_type: BlockSourceType,
-    pub block_source_from_node: Option<String>,
+    pub block_source_from_node: Option<HlNodeBlockSourceArgs>,
 }
 
 #[derive(Debug, Clone)]
 pub enum BlockSourceType {
-    S3Default,
-    S3 { bucket: String },
+    S3Default { polling_interval: Duration },
+    S3 { bucket: String, polling_interval: Duration },
     Local { path: PathBuf },
 }
 
 impl BlockSourceConfig {
-    pub async fn s3_default() -> Self {
-        Self { source_type: BlockSourceType::S3Default, block_source_from_node: None }
+    pub async fn s3_default(polling_interval: Duration) -> Self {
+        Self {
+            source_type: BlockSourceType::S3Default { polling_interval },
+            block_source_from_node: None,
+        }
     }
 
-    pub async fn s3(bucket: String) -> Self {
-        Self { source_type: BlockSourceType::S3 { bucket }, block_source_from_node: None }
+    pub async fn s3(bucket: String, polling_interval: Duration) -> Self {
+        Self {
+            source_type: BlockSourceType::S3 { bucket, polling_interval },
+            block_source_from_node: None,
+        }
     }
 
     pub fn local(path: PathBuf) -> Self {
@@ -45,15 +52,22 @@ impl BlockSourceConfig {
         }
     }
 
-    pub fn with_block_source_from_node(mut self, block_source_from_node: String) -> Self {
+    pub fn with_block_source_from_node(
+        mut self,
+        block_source_from_node: HlNodeBlockSourceArgs,
+    ) -> Self {
         self.block_source_from_node = Some(block_source_from_node);
         self
     }
 
     pub async fn create_block_source(&self, chain_spec: HlChainSpec) -> BlockSourceBoxed {
         match &self.source_type {
-            BlockSourceType::S3Default => s3_block_source(chain_spec.official_s3_bucket()).await,
-            BlockSourceType::S3 { bucket } => s3_block_source(bucket).await,
+            BlockSourceType::S3Default { polling_interval } => {
+                s3_block_source(chain_spec.official_s3_bucket(), *polling_interval).await
+            }
+            BlockSourceType::S3 { bucket, polling_interval } => {
+                s3_block_source(bucket, *polling_interval).await
+            }
             BlockSourceType::Local { path } => {
                 Arc::new(Box::new(LocalBlockSource::new(path.clone())))
             }
@@ -72,7 +86,7 @@ impl BlockSourceConfig {
         Arc::new(Box::new(
             HlNodeBlockSource::new(
                 fallback_block_source,
-                PathBuf::from(block_source_from_node.clone()),
+                block_source_from_node.clone(),
                 next_block_number,
             )
             .await,
@@ -91,9 +105,9 @@ impl BlockSourceConfig {
     }
 }
 
-async fn s3_block_source(bucket: impl AsRef<str>) -> BlockSourceBoxed {
+async fn s3_block_source(bucket: impl AsRef<str>, polling_interval: Duration) -> BlockSourceBoxed {
     let client = aws_sdk_s3::Client::new(
         &aws_config::defaults(BehaviorVersion::latest()).region("ap-northeast-1").load().await,
     );
-    Arc::new(Box::new(S3BlockSource::new(client, bucket.as_ref().to_string())))
+    Arc::new(Box::new(S3BlockSource::new(client, bucket.as_ref().to_string(), polling_interval)))
 }

--- a/src/pseudo_peer/sources/cached.rs
+++ b/src/pseudo_peer/sources/cached.rs
@@ -41,4 +41,8 @@ impl BlockSource for CachedBlockSource {
     fn recommended_chunk_size(&self) -> u64 {
         self.block_source.recommended_chunk_size()
     }
+
+    fn polling_interval(&self) -> std::time::Duration {
+        self.block_source.polling_interval()
+    }
 }

--- a/src/pseudo_peer/sources/mod.rs
+++ b/src/pseudo_peer/sources/mod.rs
@@ -1,6 +1,7 @@
 use crate::node::types::BlockAndReceipts;
+use auto_impl::auto_impl;
 use futures::future::BoxFuture;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 // Module declarations
 mod cached;
@@ -11,11 +12,14 @@ mod utils;
 
 // Public exports
 pub use cached::CachedBlockSource;
-pub use hl_node::HlNodeBlockSource;
+pub use hl_node::{HlNodeBlockSource, HlNodeBlockSourceArgs};
 pub use local::LocalBlockSource;
 pub use s3::S3BlockSource;
 
+const DEFAULT_POLLING_INTERVAL: Duration = Duration::from_millis(25);
+
 /// Trait for block sources that can retrieve blocks from various sources
+#[auto_impl(&, &mut, Box, Arc)]
 pub trait BlockSource: Send + Sync + std::fmt::Debug + Unpin + 'static {
     /// Retrieves a block at the specified height
     fn collect_block(&self, height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>>;
@@ -25,21 +29,12 @@ pub trait BlockSource: Send + Sync + std::fmt::Debug + Unpin + 'static {
 
     /// Returns the recommended chunk size for batch operations
     fn recommended_chunk_size(&self) -> u64;
+
+    /// Returns the polling interval
+    fn polling_interval(&self) -> Duration {
+        DEFAULT_POLLING_INTERVAL
+    }
 }
 
 /// Type alias for a boxed block source
 pub type BlockSourceBoxed = Arc<Box<dyn BlockSource>>;
-
-impl BlockSource for BlockSourceBoxed {
-    fn collect_block(&self, height: u64) -> BoxFuture<'static, eyre::Result<BlockAndReceipts>> {
-        self.as_ref().collect_block(height)
-    }
-
-    fn find_latest_block_number(&self) -> BoxFuture<'static, Option<u64>> {
-        self.as_ref().find_latest_block_number()
-    }
-
-    fn recommended_chunk_size(&self) -> u64 {
-        self.as_ref().recommended_chunk_size()
-    }
-}

--- a/src/pseudo_peer/sources/s3.rs
+++ b/src/pseudo_peer/sources/s3.rs
@@ -2,7 +2,7 @@ use super::{utils, BlockSource};
 use crate::node::types::BlockAndReceipts;
 use aws_sdk_s3::types::RequestPayer;
 use futures::{future::BoxFuture, FutureExt};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tracing::info;
 
 /// Block source that reads blocks from S3 (--s3)
@@ -10,11 +10,12 @@ use tracing::info;
 pub struct S3BlockSource {
     client: Arc<aws_sdk_s3::Client>,
     bucket: String,
+    polling_interval: Duration,
 }
 
 impl S3BlockSource {
-    pub fn new(client: aws_sdk_s3::Client, bucket: String) -> Self {
-        Self { client: client.into(), bucket }
+    pub fn new(client: aws_sdk_s3::Client, bucket: String, polling_interval: Duration) -> Self {
+        Self { client: client.into(), bucket, polling_interval }
     }
 
     async fn pick_path_with_highest_number(
@@ -86,5 +87,9 @@ impl BlockSource for S3BlockSource {
 
     fn recommended_chunk_size(&self) -> u64 {
         1000
+    }
+
+    fn polling_interval(&self) -> Duration {
+        self.polling_interval
     }
 }


### PR DESCRIPTION
cc/ @msobh13 @quertyy

Resolves #44 

Also you can set `AWS_MAX_ATTEMPTS` > 3 (default is 3) to adjust S3 retry counts on network congestion.

```rust
    /// Interval for polling new blocks in S3 in milliseconds.
    #[arg(id = "s3.polling-interval", long = "s3.polling-interval", default_value = "25")]
    s3_polling_interval: u64,

    /// Maximum allowed delay for the hl-node block source in milliseconds.
    /// If this threshold is exceeded, the client falls back to other sources.
    #[arg(
        id = "local.fallback-threshold",
        long = "local.fallback-threshold",
        default_value = "5000"
    )]
    local_fallback_threshold: u64,
```