### PR TITLE
fix: Disable eth_getProof by default

### DIFF
--- a/src/addons/hl_node_compliance.rs
+++ b/src/addons/hl_node_compliance.rs
@@ -659,7 +659,7 @@ where
 }
 
 pub fn install_hl_node_compliance<Node, EthApi>(
-    ctx: RpcContext<Node, EthApi>,
+    ctx: &mut RpcContext<Node, EthApi>,
 ) -> Result<(), eyre::Error>
 where
     Node: FullNodeComponents,

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> eyre::Result<()> {
             let (node, engine_handle_tx) = HlNode::new(ext.block_source_args.parse().await?);
             let NodeHandle { node, node_exit_future: exit_future } = builder
                 .node(node)
-                .extend_rpc_modules(move |ctx| {
+                .extend_rpc_modules(move |mut ctx| {
                     let upstream_rpc_url =
                         ext.upstream_rpc_url.unwrap_or_else(|| default_upstream_rpc_url.to_owned());
 
@@ -60,8 +60,13 @@ fn main() -> eyre::Result<()> {
                     }
 
                     if ext.hl_node_compliant {
-                        install_hl_node_compliance(ctx)?;
+                        install_hl_node_compliance(&mut ctx)?;
                         info!("hl-node compliant mode enabled");
+                    }
+
+                    if !ext.experimental_eth_get_proof {
+                        ctx.modules.remove_method_from_configured("eth_getProof");
+                        info!("eth_getProof is disabled by default");
                     }
 
                     Ok(())

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -55,6 +55,24 @@ pub struct HlNodeArgs {
     /// This is useful when read precompile is needed for gas estimation.
     #[arg(long, env = "FORWARD_CALL")]
     pub forward_call: bool,
+
+    /// Experimental: enables the eth_getProof RPC method.
+    ///
+    /// Note: Due to the state root difference, trie updates* may not function correctly in all
+    /// scenarios. For example, incremental root updates are not possible, which can cause
+    /// eth_getProof to malfunction in some cases.
+    ///
+    /// This limitation does not impact normal node functionality, except for state root (which is
+    /// unused) and eth_getProof. The archival state is maintained by block order, not by trie
+    /// updates. As a precaution, nanoreth disables eth_getProof by default to prevent
+    /// potential issues.
+    ///
+    /// Use --experimental-eth-get-proof to forcibly enable eth_getProof, assuming trie updates are
+    /// working as intended. Enabling this by default will be tracked in #15.
+    ///
+    /// * Refers to the Merkle trie used for eth_getProof and state root, not actual state values.
+    #[arg(long, env = "EXPERIMENTAL_ETH_GET_PROOF")]
+    pub experimental_eth_get_proof: bool,
 }
 
 /// The main reth_hl cli interface.


### PR DESCRIPTION
No need to give malfunctioning feature by default. Issue #15 affects StoragesTrie, AccountsTrie table which is used only for state root and proof generation. Also clearing the table does not affect any other parts of reth node.

Meanwhile, add --experimental-eth-get-proof flag to enable eth_getProof forcefully.

Resolves part of #15 