### PR TITLE
fix: Fill precompiles when tracing

### DIFF
--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -32,6 +32,8 @@ mod factory;
 mod patch;
 pub mod receipt_builder;
 
+pub use executor::apply_precompiles;
+
 /// HL EVM implementation.
 ///
 /// This is a wrapper type around the `revm` evm with optional [`Inspector`] (tracing)

--- a/src/node/primitives/tx_wrapper.rs
+++ b/src/node/primitives/tx_wrapper.rs
@@ -212,10 +212,6 @@ impl From<EthereumTxEnvelope<TxEip4844WithSidecar<BlobTransactionSidecarVariant>
 impl Compress for TransactionSigned {
     type Compressed = Vec<u8>;
 
-    fn compress(self) -> Self::Compressed {
-        self.into_inner().compress()
-    }
-
     fn compress_to_buf<B: bytes::BufMut + AsMut<[u8]>>(&self, buf: &mut B) {
         self.inner().compress_to_buf(buf);
     }

--- a/src/node/rpc/block.rs
+++ b/src/node/rpc/block.rs
@@ -1,4 +1,4 @@
-use crate::node::rpc::HlEthApi;
+use crate::node::rpc::{HlEthApi, HlRpcNodeCore};
 use reth::rpc::server_types::eth::{
     builder::config::PendingBlockKind, error::FromEvmError, EthApiError, PendingBlock,
 };
@@ -6,12 +6,12 @@ use reth_rpc_eth_api::{
     helpers::{
         pending_block::PendingEnvBuilder, EthBlocks, LoadBlock, LoadPendingBlock, LoadReceipt,
     },
-    RpcConvert, RpcNodeCore,
+    RpcConvert,
 };
 
 impl<N, Rpc> EthBlocks for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
@@ -19,7 +19,7 @@ where
 
 impl<N, Rpc> LoadBlock for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
@@ -27,7 +27,7 @@ where
 
 impl<N, Rpc> LoadPendingBlock for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
@@ -49,7 +49,7 @@ where
 
 impl<N, Rpc> LoadReceipt for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {

--- a/src/node/rpc/call.rs
+++ b/src/node/rpc/call.rs
@@ -1,14 +1,23 @@
-use super::HlEthApi;
+use super::{HlEthApi, HlRpcNodeCore};
+use crate::{node::evm::apply_precompiles, HlBlock};
+use alloy_evm::Evm;
+use alloy_primitives::B256;
 use reth::rpc::server_types::eth::EthApiError;
-use reth_evm::TxEnvFor;
+use reth_evm::{ConfigureEvm, Database, EvmEnvFor, TxEnvFor};
+use reth_primitives::{NodePrimitives, Recovered};
+use reth_primitives_traits::SignedTransaction;
+use reth_provider::{ProviderError, ProviderTx};
 use reth_rpc_eth_api::{
     helpers::{estimate::EstimateCall, Call, EthCall},
     FromEvmError, RpcConvert, RpcNodeCore,
 };
+use revm::DatabaseCommit;
+
+impl<N> HlRpcNodeCore for N where N: RpcNodeCore<Primitives: NodePrimitives<Block = HlBlock>> {}
 
 impl<N, Rpc> EthCall for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
@@ -16,7 +25,7 @@ where
 
 impl<N, Rpc> EstimateCall for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
@@ -24,7 +33,7 @@ where
 
 impl<N, Rpc> Call for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError, TxEnv = TxEnvFor<N::Evm>>,
 {
@@ -36,5 +45,36 @@ where
     #[inline]
     fn max_simulate_blocks(&self) -> u64 {
         self.inner.eth_api.max_simulate_blocks()
+    }
+
+    fn replay_transactions_until<'a, DB, I>(
+        &self,
+        db: &mut DB,
+        evm_env: EvmEnvFor<Self::Evm>,
+        transactions: I,
+        target_tx_hash: B256,
+    ) -> Result<usize, Self::Error>
+    where
+        DB: Database<Error = ProviderError> + DatabaseCommit + core::fmt::Debug,
+        I: IntoIterator<Item = Recovered<&'a ProviderTx<Self::Provider>>>,
+    {
+        let block_number = evm_env.block_env().number;
+        let hl_extras = self.get_hl_extras(block_number.try_into().unwrap())?;
+
+        let mut evm = self.evm_config().evm_with_env(db, evm_env);
+        apply_precompiles(&mut evm, &hl_extras);
+
+        let mut index = 0;
+        for tx in transactions {
+            if *tx.tx_hash() == target_tx_hash {
+                // reached the target transaction
+                break;
+            }
+
+            let tx_env = self.evm_config().tx_env(tx);
+            evm.transact_commit(tx_env).map_err(Self::Error::from_evm_err)?;
+            index += 1;
+        }
+        Ok(index)
     }
 }

--- a/src/node/rpc/transaction.rs
+++ b/src/node/rpc/transaction.rs
@@ -1,21 +1,21 @@
-use crate::node::rpc::HlEthApi;
+use crate::node::rpc::{HlEthApi, HlRpcNodeCore};
 use alloy_primitives::{Bytes, B256};
 use reth::rpc::server_types::eth::EthApiError;
 use reth_rpc_eth_api::{
     helpers::{spec::SignersForRpc, EthTransactions, LoadTransaction},
-    RpcConvert, RpcNodeCore,
+    RpcConvert,
 };
 
 impl<N, Rpc> LoadTransaction for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
 }
 
 impl<N, Rpc> EthTransactions for HlEthApi<N, Rpc>
 where
-    N: RpcNodeCore,
+    N: HlRpcNodeCore,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
     fn signers(&self) -> &SignersForRpc<Self::Provider, Self::NetworkTypes> {


### PR DESCRIPTION
Override the following functions to properly handle debug, trace APIs with block number:
- Trace::inspect (used for target transactions)
- Call::replay_transaction_until (used for transaction before the target transaction)

Also remove one trait implementation that is not necessary.