### PR TITLE
chore(build): add reth-hl version output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9342,6 +9342,8 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "ureq",
+ "vergen",
+ "vergen-git2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "reth_hl"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [lib]
 name = "reth_hl"
@@ -166,3 +167,7 @@ client = [
 
 [dev-dependencies]
 tempfile = "3.20.0"
+
+[build-dependencies]
+vergen = { version = "9.0.4", features = ["build", "cargo", "emit_and_set"] }
+vergen-git2 = "1.0.5"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,91 @@
+use std::{env, error::Error};
+use vergen::{BuildBuilder, CargoBuilder, Emitter};
+use vergen_git2::Git2Builder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut emitter = Emitter::default();
+
+    let build_builder = BuildBuilder::default().build_timestamp(true).build()?;
+
+    emitter.add_instructions(&build_builder)?;
+
+    let cargo_builder = CargoBuilder::default().features(true).target_triple(true).build()?;
+
+    emitter.add_instructions(&cargo_builder)?;
+
+    let git_builder =
+        Git2Builder::default().describe(false, true, None).dirty(true).sha(false).build()?;
+
+    emitter.add_instructions(&git_builder)?;
+
+    emitter.emit_and_set()?;
+    let sha = env::var("VERGEN_GIT_SHA")?;
+    let sha_short = &sha[0..7];
+
+    let is_dirty = env::var("VERGEN_GIT_DIRTY")? == "true";
+    // > git describe --always --tags
+    // if not on a tag: v0.2.0-beta.3-82-g1939939b
+    // if on a tag: v0.2.0-beta.3
+    let not_on_tag = env::var("VERGEN_GIT_DESCRIBE")?.ends_with(&format!("-g{sha_short}"));
+    let version_suffix = if is_dirty || not_on_tag { "-dev" } else { "" };
+    println!("cargo:rustc-env=RETH_HL_VERSION_SUFFIX={version_suffix}");
+
+    // Set short SHA
+    println!("cargo:rustc-env=VERGEN_GIT_SHA_SHORT={}", &sha[..8]);
+
+    // Set the build profile
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let profile = out_dir.rsplit(std::path::MAIN_SEPARATOR).nth(3).unwrap();
+    println!("cargo:rustc-env=RETH_HL_BUILD_PROFILE={profile}");
+
+    // Set formatted version strings
+    let pkg_version = env!("CARGO_PKG_VERSION");
+
+    // The short version information for reth.
+    // - The latest version from Cargo.toml
+    // - The short SHA of the latest commit.
+    // Example: 0.1.0 (defa64b2)
+    println!("cargo:rustc-env=RETH_HL_SHORT_VERSION={pkg_version}{version_suffix} ({sha_short})");
+
+    // LONG_VERSION
+    // The long version information for reth.
+    //
+    // - The latest version from Cargo.toml + version suffix (if any)
+    // - The full SHA of the latest commit
+    // - The build datetime
+    // - The build features
+    // - The build profile
+    //
+    // Example:
+    //
+    // ```text
+    // Version: 0.1.0
+    // Commit SHA: defa64b2
+    // Build Timestamp: 2023-05-19T01:47:19.815651705Z
+    // Build Features: jemalloc
+    // Build Profile: maxperf
+    // ```
+    println!("cargo:rustc-env=RETH_HL_LONG_VERSION_0=Version: {pkg_version}{version_suffix}");
+    println!("cargo:rustc-env=RETH_HL_LONG_VERSION_1=Commit SHA: {sha}");
+    println!(
+        "cargo:rustc-env=RETH_HL_LONG_VERSION_2=Build Timestamp: {}",
+        env::var("VERGEN_BUILD_TIMESTAMP")?
+    );
+    println!(
+        "cargo:rustc-env=RETH_HL_LONG_VERSION_3=Build Features: {}",
+        env::var("VERGEN_CARGO_FEATURES")?
+    );
+    println!("cargo:rustc-env=RETH_HL_LONG_VERSION_4=Build Profile: {profile}");
+
+    // The version information for reth formatted for P2P (devp2p).
+    // - The latest version from Cargo.toml
+    // - The target triple
+    //
+    // Example: reth/v0.1.0-alpha.1-428a6dc2f/aarch64-apple-darwin
+    println!(
+        "cargo:rustc-env=RETH_HL_P2P_CLIENT_VERSION={}",
+        format_args!("reth/v{pkg_version}-{sha_short}/{}", env::var("VERGEN_CARGO_TARGET_TRIPLE")?)
+    );
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ mod evm;
 mod hardforks;
 pub mod node;
 pub mod pseudo_peer;
+pub mod version;
 
 pub use node::primitives::{HlBlock, HlBlockBody, HlPrimitives};

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,9 @@ fn main() -> eyre::Result<()> {
         std::env::set_var("RUST_BACKTRACE", "1");
     }
 
+    // Initialize custom version metadata before parsing CLI so --version uses reth-hl values
+    reth_hl::version::init_reth_hl_version();
+
     Cli::<HlChainSpecParser, HlNodeArgs>::parse().run(
         |builder: WithLaunchContext<NodeBuilder<Arc<DatabaseEnv>, HlChainSpec>>,
          ext: HlNodeArgs| async move {

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,35 @@
+use std::borrow::Cow;
+
+use reth_node_core::version::{try_init_version_metadata, RethCliVersionConsts};
+
+pub fn init_reth_hl_version() {
+    let cargo_pkg_version = env!("CARGO_PKG_VERSION").to_string();
+
+    let short = env!("RETH_HL_SHORT_VERSION").to_string();
+    let long = format!(
+        "{}\n{}\n{}\n{}\n{}",
+        env!("RETH_HL_LONG_VERSION_0"),
+        env!("RETH_HL_LONG_VERSION_1"),
+        env!("RETH_HL_LONG_VERSION_2"),
+        env!("RETH_HL_LONG_VERSION_3"),
+        env!("RETH_HL_LONG_VERSION_4"),
+    );
+    let p2p = env!("RETH_HL_P2P_CLIENT_VERSION").to_string();
+
+    let meta = RethCliVersionConsts {
+        name_client: Cow::Borrowed("reth_hl"),
+        cargo_pkg_version: Cow::Owned(cargo_pkg_version.clone()),
+        vergen_git_sha_long: Cow::Owned(env!("VERGEN_GIT_SHA").to_string()),
+        vergen_git_sha: Cow::Owned(env!("VERGEN_GIT_SHA_SHORT").to_string()),
+        vergen_build_timestamp: Cow::Owned(env!("VERGEN_BUILD_TIMESTAMP").to_string()),
+        vergen_cargo_target_triple: Cow::Owned(env!("VERGEN_CARGO_TARGET_TRIPLE").to_string()),
+        vergen_cargo_features: Cow::Owned(env!("VERGEN_CARGO_FEATURES").to_string()),
+        short_version: Cow::Owned(short),
+        long_version: Cow::Owned(long),
+        build_profile_name: Cow::Owned(env!("RETH_HL_BUILD_PROFILE").to_string()),
+        p2p_client_version: Cow::Owned(p2p),
+        extra_data: Cow::Owned(format!("reth_hl/v{}/{}", cargo_pkg_version, std::env::consts::OS)),
+    };
+
+    let _ = try_init_version_metadata(meta);
+}


### PR DESCRIPTION
## Description

Previously, the `--version` flag printed Reth’s build metadata. This PR updates the CLI to report reth-hl’s own build information instead.

```bash
reth_hl Version: 0.1.0
Commit SHA: 37b852e810f2d1d44715e8d5b48cc2492caaa3fe
Build Timestamp: 2025-09-09T13:21:18.411230000Z
Build Features: default,jemalloc
Build Profile: release
```