### PR TITLE
fix(compliance): return null instead of panicking for unavailable blocks

### DIFF
--- a/src/addons/hl_node_compliance/rpc.rs
+++ b/src/addons/hl_node_compliance/rpc.rs
@@ -26,7 +26,8 @@ use reth_primitives_traits::SignedTransaction;
 use reth_provider::{BlockIdReader, BlockReader, BlockReaderIdExt, ReceiptProvider};
 use reth_rpc::{EthFilter, EthPubSub};
 use reth_rpc_eth_api::{
-    EthApiTypes, EthFilterApiServer, RpcBlock, RpcConvert, RpcReceipt, RpcTransaction,
+    EthApiTypes, EthFilterApiServer, FromEthApiError, RpcBlock, RpcConvert, RpcReceipt,
+    RpcTransaction,
     helpers::{EthBlocks, EthTransactions}, transaction::ConvertReceiptInput,
 };
 use reth_rpc_eth_types::EthApiError;
@@ -418,7 +419,9 @@ where
 
 fn adjust_log<Eth: EthWrapper>(mut log: Log, provider: &Eth::Provider) -> Option<Log> {
     let (tx_idx, log_idx) = (log.transaction_index?, log.log_index?);
-    let receipts = provider.receipts_by_block(log.block_number?.into()).unwrap()?;
+    // Without the block's receipts the log cannot be filtered, so it is dropped rather than
+    // served unadjusted.
+    let receipts = provider.receipts_by_block(log.block_number?.into()).ok()??;
     let (mut sys_tx_count, mut sys_log_count) = (0u64, 0u64);
     for receipt in receipts {
         if receipt.cumulative_gas_used() == 0 {
@@ -486,11 +489,16 @@ macro_rules! engine_span {
     };
 }
 
+/// Returns `None` if the header of the block is not available, i.e. the block cannot be filtered.
 fn adjust_block<Eth: EthWrapper>(
     recovered_block: &RpcBlock<Eth::NetworkTypes>,
     eth_api: &Eth,
-) -> RpcBlock<Eth::NetworkTypes> {
-    let system_tx_count = system_tx_count_for_block(eth_api, recovered_block.number().into());
+) -> Result<Option<RpcBlock<Eth::NetworkTypes>>, Eth::Error> {
+    let Some(system_tx_count) =
+        system_tx_count_for_block(eth_api, recovered_block.number().into())?
+    else {
+        return Ok(None);
+    };
     let mut new_block = recovered_block.clone();
 
     new_block.transactions = match new_block.transactions {
@@ -509,7 +517,7 @@ fn adjust_block<Eth: EthWrapper>(
         }
         BlockTransactions::Uncle => BlockTransactions::Uncle,
     };
-    new_block
+    Ok(Some(new_block))
 }
 
 async fn adjust_block_receipts<Eth: EthWrapper>(
@@ -517,7 +525,9 @@ async fn adjust_block_receipts<Eth: EthWrapper>(
     eth_api: &Eth,
 ) -> Result<Option<(usize, Vec<RpcReceipt<Eth::NetworkTypes>>)>, Eth::Error> {
     // Modified from EthBlocks::block_receipt. See `NOTE` comment below.
-    let system_tx_count = system_tx_count_for_block(eth_api, block_id);
+    let Some(system_tx_count) = system_tx_count_for_block(eth_api, block_id)? else {
+        return Ok(None);
+    };
     if let Some((block, receipts)) = EthBlocks::load_block_and_receipts(eth_api, block_id).await? {
         let block_number = block.number;
         let base_fee = block.base_fee_per_gas;
@@ -532,8 +542,10 @@ async fn adjust_block_receipts<Eth: EthWrapper>(
             .zip(receipts.iter())
             .enumerate()
             .filter_map(|(idx, (tx, receipt))| {
-                if receipt.cumulative_gas_used() == 0 {
-                    // NOTE: modified to exclude system tx
+                // NOTE: modified to exclude system tx. They occupy the first `system_tx_count`
+                // positions, per the count recorded in the header extras, which is also what
+                // `block_receipts_with_system_txs` partitions on.
+                if idx < system_tx_count {
                     return None;
                 }
                 let meta = TransactionMeta {
@@ -574,7 +586,9 @@ async fn block_receipts_with_system_txs<Eth: EthWrapper>(
     block_id: BlockId,
     eth_api: &Eth,
 ) -> Result<Option<BlockReceiptsWithSystemTx<RpcReceipt<Eth::NetworkTypes>>>, Eth::Error> {
-    let system_tx_count = system_tx_count_for_block(eth_api, block_id);
+    let Some(system_tx_count) = system_tx_count_for_block(eth_api, block_id)? else {
+        return Ok(None);
+    };
     if let Some((block, receipts)) = EthBlocks::load_block_and_receipts(eth_api, block_id).await? {
         let block_number = block.number;
         let base_fee = block.base_fee_per_gas;
@@ -657,20 +671,33 @@ async fn adjust_transaction_receipt<Eth: EthWrapper>(
             let Some((system_tx_count, block_receipts)) =
                 adjust_block_receipts(meta.block_hash.into(), eth_api).await?
             else {
-                unreachable!();
+                // The block went away between the two lookups, or its header isn't available.
+                return Ok(None);
             };
-            Ok(Some(block_receipts.into_iter().nth(meta.index as usize - system_tx_count).unwrap()))
+            // System transactions are hidden in compliant mode, so their receipts are not served.
+            let Some(index) = (meta.index as usize).checked_sub(system_tx_count) else {
+                return Ok(None);
+            };
+            Ok(block_receipts.into_iter().nth(index))
         }
         None => Ok(None),
     }
 }
 
-// This function assumes that `block_id` is already validated by the caller.
-fn system_tx_count_for_block<Eth: EthWrapper>(eth_api: &Eth, block_id: BlockId) -> usize {
+/// Returns the number of system transactions in the block, or `None` if the header isn't
+/// available locally (unknown block id, or a block below the earliest block this node has).
+///
+/// `block_id` comes from user input, so it must not be assumed to be valid: without the system
+/// tx count we cannot filter the block, and the caller must report the block as unknown rather
+/// than serve unfiltered data.
+fn system_tx_count_for_block<Eth: EthWrapper>(
+    eth_api: &Eth,
+    block_id: BlockId,
+) -> Result<Option<usize>, Eth::Error> {
     let provider = eth_api.provider();
-    let header = provider.header_by_id(block_id).unwrap().unwrap();
+    let header = provider.header_by_id(block_id).map_err(Eth::Error::from_eth_err)?;
 
-    header.extras.system_tx_count.try_into().unwrap()
+    Ok(header.map(|header| header.extras.system_tx_count as usize))
 }
 
 #[async_trait]
@@ -689,7 +716,10 @@ where
     ) -> RpcResult<Option<RpcBlock<Eth::NetworkTypes>>> {
         let res = self.eth_api.block_by_hash(hash, full).instrument(engine_span!()).await?;
         if is_hl_compliant(ext, self.default_compliant) {
-            Ok(res.map(|block| adjust_block(&block, &*self.eth_api)))
+            match res {
+                Some(block) => Ok(adjust_block(&block, &*self.eth_api)?),
+                None => Ok(None),
+            }
         } else {
             Ok(res)
         }
@@ -705,7 +735,10 @@ where
         trace!(target: "rpc::eth", ?number, ?full, "Serving eth_getBlockByNumber");
         let res = self.eth_api.block_by_number(number, full).instrument(engine_span!()).await?;
         if is_hl_compliant(ext, self.default_compliant) {
-            Ok(res.map(|block| adjust_block(&block, &*self.eth_api)))
+            match res {
+                Some(block) => Ok(adjust_block(&block, &*self.eth_api)?),
+                None => Ok(None),
+            }
         } else {
             Ok(res)
         }
@@ -721,11 +754,13 @@ where
         let res =
             self.eth_api.block_transaction_count_by_hash(hash).instrument(engine_span!()).await?;
         if is_hl_compliant(ext, self.default_compliant) {
-            Ok(res.map(|count| {
-                let sys_tx_count =
-                    system_tx_count_for_block(&*self.eth_api, BlockId::Hash(hash.into()));
-                count - U256::from(sys_tx_count)
-            }))
+            let Some(count) = res else { return Ok(None) };
+            let Some(sys_tx_count) =
+                system_tx_count_for_block(&*self.eth_api, BlockId::Hash(hash.into()))?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(count - U256::from(sys_tx_count)))
         } else {
             Ok(res)
         }
@@ -744,9 +779,12 @@ where
             .instrument(engine_span!())
             .await?;
         if is_hl_compliant(ext, self.default_compliant) {
-            Ok(res.map(|count| {
-                count - U256::from(system_tx_count_for_block(&*self.eth_api, number.into()))
-            }))
+            let Some(count) = res else { return Ok(None) };
+            let Some(sys_tx_count) = system_tx_count_for_block(&*self.eth_api, number.into())?
+            else {
+                return Ok(None);
+            };
+            Ok(Some(count - U256::from(sys_tx_count)))
         } else {
             Ok(res)
         }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -89,3 +89,64 @@ echo "$TRACE_RESULT" | jq -e \
     ($hashes | index($success) != null)
     ' > /dev/null \
     && success "$TITLE" || fail "$TITLE - trace_block missing expected tx hashes"
+
+TITLE="Issue #143 - unknown/unavailable blocks must return null instead of panicking"
+UNKNOWN_HASH=0x1111111111111111111111111111111111111111111111111111111111111111
+FUTURE_BLOCK=0x7fffffffff
+for REQ in \
+    "eth_getBlockReceipts:[\"$UNKNOWN_HASH\"]" \
+    "eth_getBlockReceipts:[\"$FUTURE_BLOCK\"]" \
+    "eth_getBlockByHash:[\"$UNKNOWN_HASH\",false]" \
+    "eth_getBlockByNumber:[\"$FUTURE_BLOCK\",false]" \
+    "eth_getBlockTransactionCountByHash:[\"$UNKNOWN_HASH\"]" \
+    "eth_getBlockTransactionCountByNumber:[\"$FUTURE_BLOCK\"]" \
+    "eth_getTransactionReceipt:[\"$UNKNOWN_HASH\"]" \
+    ; do
+    METHOD=${REQ%%:*}
+    PARAMS=${REQ#*:}
+    RESULT=$(curl -sS -H 'content-type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$METHOD\",\"params\":$PARAMS}" \
+        "$ETH_RPC_URL")
+    echo "$RESULT" | jq -e '(.error | not) and (.result == null)' > /dev/null \
+        || fail "$TITLE - $METHOD returned $RESULT"
+done
+success "$TITLE"
+
+TITLE="Issue #143 - the pending tag must not panic (locally built pending block has no header)"
+for METHOD in eth_getBlockByNumber eth_getBlockTransactionCountByNumber; do
+    PARAMS='["pending",false]'
+    [[ "$METHOD" == eth_getBlockTransactionCountByNumber ]] && PARAMS='["pending"]'
+    RESULT=$(curl -sS -H 'content-type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$METHOD\",\"params\":$PARAMS}" \
+        "$ETH_RPC_URL")
+    echo "$RESULT" | jq -e '(.error | not) and has("result")' > /dev/null \
+        || fail "$TITLE - $METHOD returned $RESULT"
+done
+success "$TITLE"
+
+TITLE="Issue #143 - a system tx receipt must return null instead of panicking"
+# System txs are hidden in compliant mode, so their index is below the block's system tx count
+# and the adjusted index used to underflow. Walk back from the head until a block with system
+# txs turns up; they are sparse on testnet, so allow the window to be widened.
+SCAN_FROM=${SYSTEM_TX_SCAN_FROM:-$(curl -sS -H 'content-type: application/json' \
+    -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber","params":[]}' "$ETH_RPC_URL" \
+    | jq -r '.result' | { read -r hex; printf '%d' "$hex"; })}
+SCAN_BLOCKS=${SYSTEM_TX_SCAN_BLOCKS:-2000}
+SYSTEM_TX=""
+for ((i = 0; i < SCAN_BLOCKS; i++)); do
+    BLOCK=$(printf '0x%x' $((SCAN_FROM - i)))
+    SYSTEM_TX=$(curl -sS -H 'content-type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getBlockReceiptsWithSystemTx\",\"params\":[\"$BLOCK\"]}" \
+        "$ETH_RPC_URL" | jq -r '.result.systemTxReceipts[0].transactionHash // empty')
+    [[ -n "$SYSTEM_TX" ]] && break
+done
+if [[ -n "$SYSTEM_TX" ]]; then
+    RESULT=$(curl -sS -H 'content-type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"eth_getTransactionReceipt\",\"params\":[\"$SYSTEM_TX\"]}" \
+        "$ETH_RPC_URL")
+    echo "$RESULT" | jq -e '(.error | not) and (.result == null)' > /dev/null \
+        && success "$TITLE ($SYSTEM_TX)" || fail "$TITLE - $SYSTEM_TX returned $RESULT"
+else
+    echo "Skipped: $TITLE - no system tx in the last $SCAN_BLOCKS blocks;" \
+        "set SYSTEM_TX_SCAN_FROM/SYSTEM_TX_SCAN_BLOCKS to widen the search"
+fi


### PR DESCRIPTION
Fixes #143.

## Root cause

`system_tx_count_for_block` assumed the caller had validated `block_id`, but it runs before any
block lookup on raw user input, so `header_by_id` returns `Ok(None)` and the second `unwrap()`
panics a tokio worker.

The reported trigger turned out **not** to be pruned/below-earliest blocks. Those return `null`
via the existing `block_by_id` guard, and a testnet datadir carries real headers from block 0
anyway (`init-state --without-evm` writes placeholder headers for every block below the start
height — verified against a public testnet snapshot: `static_file_headers_*` are populated for
segments 0-99, while `transactions`/`receipts` are empty below `34000000_34499999`).

The actual trigger is **`eth_getBlockByNumber("pending")`**. reth's default `PendingBlockKind` is
`Full`, so the EthApi builds a local pending block numbered `latest + 1`, and `adjust_block` then
asks the provider for a header that by definition is not in the database.

## Fix

`system_tx_count_for_block` now returns `Result<Option<usize>, Eth::Error>`: provider errors
propagate as RPC errors and a missing header makes the caller report the block as unknown.
Returning `null` rather than unfiltered data matters here, since the system tx count is what makes
the response compliant.

Two neighbouring panics on the same paths are fixed as well:

- `adjust_transaction_receipt` underflowed `meta.index - system_tx_count` and panicked on
  `.nth(..).unwrap()` for a receipt request on any system tx hash, which is hidden in compliant
  mode. Those now return null, as does the block-vanished race that was `unreachable!()`.
- `adjust_log` unwrapped the `receipts_by_block` provider result; the log is now dropped instead
  of panicking the subscription task.

`safe`/`finalized` before the CL sets them hit `ProviderError::FinalizedBlockNotFound`, which
panicked on the *first* unwrap; that now surfaces as an RPC error.

## Why the index arithmetic is not clamped

An earlier revision of this branch wrapped every subtraction in `saturating_sub`. That was wrong:
clamping would emit `transactionIndex: 0` for a transaction that is not index 0, in the one module
whose job is emitting correct indices, and `adjust_transaction_receipt` would then `nth()` the
wrong receipt entirely. `overflowing_sub` is no better unless the flag is acted on, at which point
it is a wordier `checked_sub`. (`count - U256::from(..)` never panicked in the first place — ruint
implements `Sub` as `wrapping_sub`.)

The second commit removes the need for clamping instead. `adjust_block_receipts` decided what to
drop with `cumulative_gas_used == 0` but computed the adjusted index from
`header.extras.system_tx_count`. Those are two different definitions of "system transaction",
and there are three in the codebase:

| notion | definition | used by |
|---|---|---|
| A | `header.extras.system_tx_count`, a prefix length | `adjust_block`, `getBlockTransactionCount*`, `block_receipts_with_system_txs`, the offset in `adjust_transaction_receipt` |
| B | `receipt.cumulative_gas_used == 0` | `adjust_block_receipts`' filter, `adjust_log` |
| C | `gas_price == 0`, anywhere in the block | `evm/config.rs` when building the header, `eth_getEvmSystemTxsByBlock*` |

A receipt reads zero only because `HlBlockExecutor::execute_transaction` skips accumulating gas
for system txs, so the value stays zero for as long as the block's system tx prefix lasts. If a
zero-gas-price tx ever landed after a gas-consuming one, B would not drop it while A counted it —
leaking a system tx receipt to compliant clients and shifting every following index by one.
Partitioning on `idx < system_tx_count` (what `block_receipts_with_system_txs` already does) makes
the arithmetic non-negative by construction and stops `eth_getBlockReceipts` and
`eth_getBlockReceiptsWithSystemTx` from disagreeing about the same block.

`adjust_log` (notion B) and `eth_getEvmSystemTxsByBlock*` (notion C) are left alone here; those
inconsistencies predate this PR and deserve their own change.

## Verification

Release builds of `nb-20260613` and this branch, run against the same testnet snapshot datadir
with `--chain testnet --hl-node-compliant`, head at block 49675750.

Both panics reproduce on the unpatched binary and are gone on this branch:

| request | unpatched | this branch |
|---|---|---|
| `eth_getBlockByNumber("pending")` | panic at `rpc.rs:671:59`, client gets `Empty reply from server` | `null`, 0 panics under 200 concurrent calls |
| `eth_getTransactionReceipt(<system tx>)` | panic at `rpc.rs:662:91` | `null`, 0 panics |

The first is identical in line and column to the report in #143. Every other candidate — unknown
hash, future number, block `0x1`, `safe`, `finalized`, `eth_getBlockReceipts`,
`eth_getTransactionReceipt` on an unknown hash — returned `null` with zero panics on both
binaries.

No regression on the normal path, over two response sets captured from both binaries:

- 28 blocks that **contain system transactions** (found by scanning 50k blocks; they are sparse on
  testnet), covering `eth_getBlockReceipts`, `eth_getBlockReceiptsWithSystemTx`,
  `eth_getBlockByNumber(full)`, `getBlockTransactionCountByNumber`, `eth_getEvmSystemTxsByBlockNumber`,
  `eth_getTransactionReceipt` for every regular tx, and per-block `eth_getLogs` — 171 responses,
  byte-identical (`d3c69d2062d5dc043cf9772614f43985`). This is the set that exercises the
  partitioning change.
- 16 blocks without system transactions, 109 responses, byte-identical
  (`b00c8311855560e8fe0fcefbcb398a92`). Note this set says nothing about the partitioning change:
  with `system_tx_count == 0` both the old and new filters are no-ops.

`tests/run_tests.sh` gains the issue-143 checks: seven methods against unknown-hash/future-number
asserting `result: null`, a `pending` no-panic check, and a system tx receipt check that discovers
a system tx by walking back from the head. The last one fails on `nb-20260613` and passes here.
