### PR TITLE
feat(rpc): resolve read precompiles at the chain head through an hl-node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9419,6 +9419,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "revm",
+ "revm-inspectors",
  "rmp-serde",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ futures = "0.3"
 lazy_static = "1.4.0"
 once_cell = { version = "1.19", default-features = false, features = ["critical-section"] }
 parking_lot = "0.12"
+revm-inspectors = "0.30.0"
 serde = { version = "1.0", features = ["derive"], default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 thiserror = { version = "2.0.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,36 @@ reth-hl node --http --http.api eth,ots,net,web3 \
 
 The `--rpc.polling-interval` flag controls how often the local node polls for new blocks (default: 100ms).
 
+## Read precompiles on the latest block
+
+Blocks only carry the read precompile calls their own transactions made, so `eth_call`,
+`eth_estimateGas` and `debug_traceCall` against `latest` fail with out-of-gas as soon as they
+touch HyperCore state that no transaction has read yet — which wallets routinely do when
+estimating gas.
+
+`--forward-read-precompiles` fixes this without giving up local execution: the call still runs in
+nanoreth's EVM, and only the unrecorded read precompile inputs are resolved through an hl-node.
+State overrides, block overrides and tracing therefore keep working, unlike `--forward-call`,
+which hands the whole call to the upstream RPC.
+
+```sh
+# hl-node serving its EVM RPC on the default port
+$ hl-node run-non-validator --replica-cmds-style recent-actions --serve-eth-rpc --disable-output-file-buffering
+
+$ reth-hl node --http --http.api eth,ots,net,web3,debug --local \
+    --forward-read-precompiles --read-precompile-rpc-url http://localhost:3001/evm
+```
+
+`--read-precompile-rpc-url` defaults to `--upstream-rpc-url` (Hyperliquid's public RPC), but
+pointing it at a local hl-node avoids that endpoint's rate limits.
+`--read-precompile-rpc-rate-limit <requests-per-second>` optionally paces forwarded requests;
+identical concurrent reads are coalesced before the limit is applied. Configure it according to
+the selected upstream, or use a local hl-node for production traffic. Official public RPC URLs
+default to 5 requests/s, while custom URLs are unlimited unless this option is set.
+
+Only the chain head forwards. Historical blocks replay from their recorded calls, because
+HyperCore state is not archived and forwarding an old call would answer it with today's values.
+
 ## Architecture: How nanoreth differs from reth
 
 Nanoreth replaces reth's native P2P sync pipeline with a **pseudo peer + block source** architecture:

--- a/src/evm/transaction.rs
+++ b/src/evm/transaction.rs
@@ -17,11 +17,28 @@ pub trait HlTxTr: Transaction {}
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HlTxEnv<T: Transaction> {
     pub base: T,
+    #[cfg_attr(feature = "serde", serde(skip))]
+    pub rpc_state_block_number: Option<u64>,
 }
 
 impl<T: Transaction> HlTxEnv<T> {
     pub fn new(base: T) -> Self {
-        Self { base }
+        Self { base, rpc_state_block_number: None }
+    }
+}
+
+pub trait HlTxEnvExt {
+    fn rpc_state_block_number(&self) -> Option<u64>;
+    fn set_rpc_state_block_number(&mut self, block_number: u64);
+}
+
+impl<T: Transaction> HlTxEnvExt for HlTxEnv<T> {
+    fn rpc_state_block_number(&self) -> Option<u64> {
+        self.rpc_state_block_number
+    }
+
+    fn set_rpc_state_block_number(&mut self, block_number: u64) {
+        self.rpc_state_block_number = Some(block_number);
     }
 }
 
@@ -133,7 +150,7 @@ impl FromTxWithEncoded<TransactionSigned> for HlTxEnv<TxEnv> {
             Transaction::Eip7702(tx) => TxEnv::from_recovered_tx(&tx, sender),
         };
 
-        Self { base }
+        Self { base, rpc_state_block_number: None }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{num::NonZeroU32, sync::Arc};
 
 use clap::Parser;
 use reth::{
@@ -18,13 +18,14 @@ use reth_hl::{
     node::{
         HlNode,
         cli::{Cli, HlNodeArgs},
+        evm::read_precompile_forwarder::{ReadPrecompileForwarder, set_read_precompile_forwarder},
         rpc::precompile::{HlBlockPrecompileApiServer, HlBlockPrecompileExt},
         spot_meta::{self, init as spot_meta_init},
         storage::tables::Tables,
         types::set_spot_metadata_db,
     },
 };
-use tracing::info;
+use tracing::{info, warn};
 
 // We use jemalloc for performance reasons
 #[cfg(all(feature = "jemalloc", unix))]
@@ -68,6 +69,10 @@ fn main() -> eyre::Result<()> {
                 Arc::new(std::sync::Mutex::new(CapturedMethods { http: None, ws: None, ipc: None }));
             let captured_for_restart = captured.clone();
 
+            // Captured here so the read precompile forwarder can drive requests from the
+            // blocking RPC workers that precompiles run on.
+            let runtime_handle = tokio::runtime::Handle::current();
+
             let (node, engine_handle_tx) = HlNode::new(
                 ext.block_source_args.parse().await?,
                 ext.debug_cutoff_height,
@@ -93,6 +98,44 @@ fn main() -> eyre::Result<()> {
                             .into_rpc(),
                         )?;
                         info!("Call/gas estimation will be forwarded to {}", upstream_rpc_url);
+                    }
+
+                    if ext.forward_read_precompiles {
+                        let read_precompile_rpc_url = ext
+                            .read_precompile_rpc_url
+                            .clone()
+                            .unwrap_or_else(|| upstream_rpc_url.clone());
+                        let read_precompile_rpc_rate_limit = ext
+                            .read_precompile_rpc_rate_limit
+                            .or_else(|| {
+                                (read_precompile_rpc_url == default_upstream_rpc_url)
+                                    .then(|| NonZeroU32::new(5).unwrap())
+                            });
+                        set_read_precompile_forwarder(ReadPrecompileForwarder::new(
+                            &read_precompile_rpc_url,
+                            runtime_handle.clone(),
+                            read_precompile_rpc_rate_limit,
+                        )?);
+                        info!(
+                            "Read precompile calls at the chain head will be resolved through {}",
+                            read_precompile_rpc_url
+                        );
+                        if let Some(rate_limit) = read_precompile_rpc_rate_limit {
+                            info!(
+                                "Forwarded read precompile calls are limited to {} requests/s",
+                                rate_limit
+                            );
+                        }
+                        // Resolving against the official RPC works, but it is rate limited and
+                        // every unrecorded input costs a request, so it is easy to get throttled
+                        // without noticing why calls started failing.
+                        if read_precompile_rpc_url == default_upstream_rpc_url {
+                            warn!(
+                                "{} is rate limited; set --read-precompile-rpc-url to your own \
+                                 hl-node to avoid being throttled",
+                                read_precompile_rpc_url
+                            );
+                        }
                     }
 
                     // This is a temporary workaround to fix the issue with custom headers

--- a/src/node/cli.rs
+++ b/src/node/cli.rs
@@ -22,6 +22,7 @@ use reth_db::{DatabaseEnv, init_db, mdbx::init_db_for};
 use reth_tracing::FileWorkerGuard;
 use std::{
     fmt::{self},
+    num::NonZeroU32,
     sync::Arc,
 };
 use tracing::info;
@@ -72,6 +73,33 @@ pub struct HlNodeArgs {
     /// This is useful when read precompile is needed for gas estimation.
     #[arg(long, env = "FORWARD_CALL")]
     pub forward_call: bool,
+
+    /// Resolve read precompile calls at the chain head through an hl-node.
+    ///
+    /// Blocks only record the read precompile calls their own transactions made, so a call
+    /// against the head that reads HyperCore state nanoreth has never seen fails with
+    /// out-of-gas. With this enabled, eth_call, eth_estimateGas and debug_traceCall still run
+    /// locally, but any unrecorded read precompile input is answered by the node at
+    /// --read-precompile-rpc-url.
+    ///
+    /// Unlike --forward-call this keeps execution local, so state overrides and tracing keep
+    /// working. Historical blocks are unaffected: they replay from their recorded calls.
+    #[arg(long, env = "FORWARD_READ_PRECOMPILES")]
+    pub forward_read_precompiles: bool,
+
+    /// RPC URL used to resolve forwarded read precompile calls.
+    ///
+    /// Defaults to --upstream-rpc-url. Point it at a local hl-node (for example
+    /// http://localhost:3001/evm) to avoid the public RPC's rate limits.
+    #[arg(long, env = "READ_PRECOMPILE_RPC_URL")]
+    pub read_precompile_rpc_url: Option<String>,
+
+    /// Maximum forwarded read precompile requests per second.
+    ///
+    /// Defaults to 5 for an official public RPC and unlimited for a custom URL. Identical
+    /// concurrent requests are coalesced before this limit is applied.
+    #[arg(long, env = "READ_PRECOMPILE_RPC_RATE_LIMIT")]
+    pub read_precompile_rpc_rate_limit: Option<NonZeroU32>,
 
     /// Experimental: enables the eth_getProof RPC method.
     ///

--- a/src/node/evm/config.rs
+++ b/src/node/evm/config.rs
@@ -1,3 +1,4 @@
+use super::ScopedReadPrecompileForwarder;
 use super::{executor::HlBlockExecutor, factory::HlEvmFactory};
 use crate::{
     HlBlock, HlBlockBody, HlHeader, HlPrimitives,
@@ -236,6 +237,25 @@ impl<R, Spec, EvmFactory> HlBlockExecutorFactory<R, Spec, EvmFactory> {
 pub struct HlBlockExecutionCtx<'a> {
     ctx: EthBlockExecutionCtx<'a>,
     pub extras: HlExtras,
+    /// Resolves read precompile inputs that `extras` did not record.
+    ///
+    /// Only the RPC simulation path sets this, and only for blocks that were never mined.
+    /// Executing a real block must leave it `None`: there the recorded calls are consensus data,
+    /// and an input missing from them means the block itself is wrong.
+    read_precompile_forwarder: Option<ScopedReadPrecompileForwarder>,
+}
+
+impl HlBlockExecutionCtx<'_> {
+    pub(crate) fn enable_rpc_read_precompile_forwarding(
+        &mut self,
+        forwarder: Option<ScopedReadPrecompileForwarder>,
+    ) {
+        self.read_precompile_forwarder = forwarder;
+    }
+
+    pub(super) fn read_precompile_forwarder(&self) -> Option<ScopedReadPrecompileForwarder> {
+        self.read_precompile_forwarder.clone()
+    }
 }
 
 impl<R, Spec, EvmF> BlockExecutorFactory for HlBlockExecutorFactory<R, Spec, EvmF>
@@ -394,6 +414,7 @@ where
                 read_precompile_calls: block_body.read_precompile_calls.clone(),
                 highest_precompile_address: block_body.highest_precompile_address,
             },
+            read_precompile_forwarder: None,
         })
     }
 
@@ -409,7 +430,11 @@ where
                 ommers: &[],
                 withdrawals: attributes.withdrawals.map(Cow::Owned),
             },
-            extras: HlExtras::default(), // TODO: hacky, double check if this is correct
+            // A block that has not been mined has no recorded calls of its own. The RPC
+            // simulation path overwrites this with the head's precompile address range and a
+            // forwarder; see `HlEthApi::simulate_v1`.
+            extras: HlExtras::default(),
+            read_precompile_forwarder: None,
         })
     }
 }
@@ -432,6 +457,7 @@ impl ConfigureEngineEvm<HlExecutionData> for HlEvmConfig {
                 read_precompile_calls: block.body.read_precompile_calls.clone(),
                 highest_precompile_address: block.body.highest_precompile_address,
             },
+            read_precompile_forwarder: None,
         }
     }
 

--- a/src/node/evm/executor.rs
+++ b/src/node/evm/executor.rs
@@ -1,4 +1,7 @@
-use super::{config::HlBlockExecutionCtx, patch::patch_mainnet_after_tx};
+use super::{
+    config::HlBlockExecutionCtx, patch::patch_mainnet_after_tx,
+    read_precompile_forwarder::ReadPrecompileForwarder,
+};
 use crate::{
     evm::transaction::HlTxEnv,
     hardforks::HlHardforks,
@@ -10,7 +13,7 @@ use crate::{
 use alloy_consensus::{Transaction, TxReceipt};
 use alloy_eips::{Encodable2718, eip7685::Requests};
 use alloy_evm::{block::ExecutableTx, eth::receipt_builder::ReceiptBuilderCtx};
-use alloy_primitives::{Address, Bytes, U160, U256, address, hex};
+use alloy_primitives::{Address, B256, Bytes, U160, U256, address, hex};
 use reth_chainspec::{EthChainSpec, EthereumHardforks, Hardforks};
 use reth_evm::{
     Database, Evm, FromRecoveredTx, FromTxWithEncoded, IntoTxEnv, OnStateHook,
@@ -29,6 +32,9 @@ use revm::{
     primitives::HashMap,
     state::Bytecode,
 };
+use std::sync::Arc;
+
+pub type ScopedReadPrecompileForwarder = (Arc<ReadPrecompileForwarder>, B256);
 
 pub fn is_system_transaction(tx: &TransactionSigned) -> bool {
     let Some(gas_price) = tx.gas_price() else {
@@ -57,17 +63,17 @@ where
     ctx: HlBlockExecutionCtx<'a>,
 }
 
+/// Replays a read precompile call from the calls recorded in the block body, or returns [`None`]
+/// if the block did not record this exact input.
 fn run_precompile(
     precompile_calls: &HashMap<ReadPrecompileInput, ReadPrecompileResult>,
     data: &[u8],
     gas_limit: u64,
-) -> PrecompileResult {
+) -> Option<PrecompileResult> {
     let input = ReadPrecompileInput { input: Bytes::copy_from_slice(data), gas_limit };
-    let Some(get) = precompile_calls.get(&input) else {
-        return Err(PrecompileError::OutOfGas);
-    };
+    let get = precompile_calls.get(&input)?;
 
-    match *get {
+    Some(match *get {
         ReadPrecompileResult::Ok { gas_used, ref bytes } => {
             Ok(PrecompileOutput { gas_used, bytes: bytes.clone(), reverted: false })
         }
@@ -77,6 +83,25 @@ fn run_precompile(
         }
         ReadPrecompileResult::Error => Err(PrecompileError::OutOfGas),
         ReadPrecompileResult::UnexpectedError => panic!("unexpected precompile error"),
+    })
+}
+
+/// Answers a read precompile call that the block did not record.
+///
+/// Without a forwarder there is nothing to answer with, so the call burns its gas limit — which
+/// is the historical behaviour for any unrecorded input.
+fn run_unrecorded_precompile(
+    forwarder: Option<&ScopedReadPrecompileForwarder>,
+    address: Address,
+    data: &[u8],
+    gas_limit: u64,
+    block_number: u64,
+) -> PrecompileResult {
+    match forwarder {
+        Some((forwarder, head_hash)) => {
+            forwarder.call(address, data, gas_limit, block_number, *head_hash)
+        }
+        None => Err(PrecompileError::OutOfGas),
     }
 }
 
@@ -99,7 +124,7 @@ where
 {
     /// Creates a new HlBlockExecutor.
     pub fn new(mut evm: EVM, ctx: HlBlockExecutionCtx<'a>, spec: Spec, receipt_builder: R) -> Self {
-        apply_precompiles(&mut evm, &ctx.extras);
+        apply_precompiles_with_forwarder(&mut evm, &ctx.extras, ctx.read_precompile_forwarder());
         Self { spec, evm, gas_used: 0, receipts: vec![], receipt_builder, ctx }
     }
 
@@ -154,7 +179,11 @@ where
     type Evm = E;
 
     fn apply_pre_execution_changes(&mut self) -> Result<(), BlockExecutionError> {
-        apply_precompiles(&mut self.evm, &self.ctx.extras);
+        apply_precompiles_with_forwarder(
+            &mut self.evm,
+            &self.ctx.extras,
+            self.ctx.read_precompile_forwarder(),
+        );
         self.deploy_corewriter_contract()?;
 
         Ok(())
@@ -246,6 +275,22 @@ pub fn apply_precompiles<EVM>(evm: &mut EVM, extras: &HlExtras)
 where
     EVM: Evm<Precompiles = PrecompilesMap>,
 {
+    apply_precompiles_with_forwarder(evm, extras, None)
+}
+
+/// Same as [`apply_precompiles`], but resolves read precompile inputs that the block did not
+/// record through `forwarder` instead of burning their gas limit.
+///
+/// Only the RPC call paths pass a forwarder, and only for the chain head. Block execution must
+/// never forward: the recorded calls are consensus data, and an unrecorded input there means the
+/// block itself is wrong.
+pub fn apply_precompiles_with_forwarder<EVM>(
+    evm: &mut EVM,
+    extras: &HlExtras,
+    forwarder: Option<ScopedReadPrecompileForwarder>,
+) where
+    EVM: Evm<Precompiles = PrecompilesMap>,
+{
     let block_number = evm.block().number;
     let precompiles_mut = evm.precompiles_mut();
     // For all precompile addresses just in case it's populated and not cleared
@@ -258,11 +303,21 @@ where
     }
     for (address, precompile) in extras.read_precompile_calls.clone().unwrap_or_default().0.iter() {
         let precompile = precompile.clone();
-        precompiles_mut.apply_precompile(address, |_| {
+        let forwarder = forwarder.clone();
+        let address = *address;
+        precompiles_mut.apply_precompile(&address, |_| {
             let precompiles_map: HashMap<ReadPrecompileInput, ReadPrecompileResult> =
                 precompile.iter().map(|(input, result)| (input.clone(), result.clone())).collect();
             Some(DynPrecompile::from(move |input: PrecompileInput| -> PrecompileResult {
-                run_precompile(&precompiles_map, input.data, input.gas)
+                run_precompile(&precompiles_map, input.data, input.gas).unwrap_or_else(|| {
+                    run_unrecorded_precompile(
+                        forwarder.as_ref(),
+                        address,
+                        input.data,
+                        input.gas,
+                        block_number.saturating_to(),
+                    )
+                })
             }))
         });
     }
@@ -270,7 +325,7 @@ where
     // NOTE: This is adapted from hyperliquid-dex/hyper-evm-sync#5
     const WARM_PRECOMPILES_BLOCK_NUMBER: u64 = 8_197_684;
     if block_number >= U256::from(WARM_PRECOMPILES_BLOCK_NUMBER) {
-        fill_all_precompiles(extras, precompiles_mut);
+        fill_all_precompiles(extras, precompiles_mut, forwarder, block_number.saturating_to());
     }
 }
 
@@ -278,18 +333,30 @@ fn address_to_u64(address: Address) -> u64 {
     address.into_u256().try_into().unwrap()
 }
 
-fn fill_all_precompiles(extras: &HlExtras, precompiles_mut: &mut PrecompilesMap) {
+fn fill_all_precompiles(
+    extras: &HlExtras,
+    precompiles_mut: &mut PrecompilesMap,
+    forwarder: Option<ScopedReadPrecompileForwarder>,
+    block_number: u64,
+) {
     let lowest_address = 0x800;
     let highest_address = extras.highest_precompile_address.map_or(0x80D, address_to_u64);
     for address in lowest_address..=highest_address {
         let address = Address::from(U160::from(address));
+        let forwarder = forwarder.clone();
         precompiles_mut.apply_precompile(&address, |f| {
             if let Some(precompile) = f {
                 return Some(precompile);
             }
 
-            Some(DynPrecompile::from(move |_: PrecompileInput| -> PrecompileResult {
-                Err(PrecompileError::OutOfGas)
+            Some(DynPrecompile::from(move |input: PrecompileInput| -> PrecompileResult {
+                run_unrecorded_precompile(
+                    forwarder.as_ref(),
+                    address,
+                    input.data,
+                    input.gas,
+                    block_number,
+                )
             }))
         });
     }

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -30,9 +30,12 @@ pub mod config;
 mod executor;
 mod factory;
 mod patch;
+pub mod read_precompile_forwarder;
 pub mod receipt_builder;
 
-pub use executor::apply_precompiles;
+pub use executor::{
+    ScopedReadPrecompileForwarder, apply_precompiles, apply_precompiles_with_forwarder,
+};
 
 /// HL EVM implementation.
 ///

--- a/src/node/evm/read_precompile_forwarder.rs
+++ b/src/node/evm/read_precompile_forwarder.rs
@@ -1,0 +1,424 @@
+//! Serves read precompile calls at the chain head by forwarding them to an hl-node.
+//!
+//! Every block body carries the read precompile calls that its own transactions made
+//! (`ReadPrecompileCalls`), which is all that re-executing a historical block needs. It is not
+//! enough for `eth_call` / `eth_estimateGas` / `debug_traceCall` against the chain head: those
+//! run inputs that no transaction has made yet, and nanoreth holds no HyperCore state of its own
+//! to answer them with, so today they fail with out-of-gas. This module forwards such inputs to a
+//! node that does hold that state — typically a local hl-node — and prices the response locally.
+//!
+//! See <https://github.com/hl-archive-node/nanoreth/issues/26>.
+
+use alloy_primitives::{Address, B256, Bytes};
+use jsonrpsee::{
+    http_client::{HttpClient, HttpClientBuilder},
+    rpc_params,
+    types::ErrorObject,
+};
+use jsonrpsee_core::{ClientError, client::ClientT};
+use parking_lot::{Condvar, Mutex};
+use revm::precompile::{PrecompileError, PrecompileOutput, PrecompileResult};
+use std::{
+    collections::HashMap,
+    num::NonZeroU32,
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant},
+};
+use tokio::runtime::Handle;
+use tracing::{debug, warn};
+
+/// Gas an HL read precompile charges regardless of payload size.
+pub const READ_PRECOMPILE_BASE_GAS: u64 = 1000;
+
+/// Gas an HL read precompile charges per byte of input plus output.
+pub const READ_PRECOMPILE_GAS_PER_BYTE: u64 = 33;
+
+/// Gas charged by a read precompile for the given input and output sizes.
+///
+/// hl-node does not report the gas a read precompile used over `eth_call`, but it is a pure
+/// function of the payload sizes, so the forwarder only has to fetch the output bytes. The
+/// constants were measured by binary searching the minimum gas limit that lets a direct call to
+/// each precompile succeed on mainnet; see the tests below for the samples they were fit to.
+pub const fn read_precompile_gas(input_len: usize, output_len: usize) -> u64 {
+    READ_PRECOMPILE_BASE_GAS + READ_PRECOMPILE_GAS_PER_BYTE * (input_len as u64 + output_len as u64)
+}
+
+/// Timeout for a single forwarded call.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Upper bound on cached responses, so that a long-lived head cannot grow the cache without
+/// bound.
+const MAX_CACHE_ENTRIES: usize = 16_384;
+
+/// What the upstream said about one `(address, input)` pair.
+#[derive(Clone, Debug)]
+enum Response {
+    /// The precompile returned these bytes.
+    Output(Bytes),
+    /// The precompile rejected the input.
+    Rejected,
+}
+
+/// Responses, keyed by the canonical head they were fetched for.
+///
+/// The block number and hash are part of the key rather than a scope for the whole map, because
+/// calls at the head and calls at the pending block are in flight at the same time — `eth_call`
+/// against `latest` sits at the head while `eth_simulateV1` builds on top of it. The hash keeps a
+/// same-height reorg from reusing responses fetched for the replaced head.
+#[derive(Debug, Default)]
+struct Cache {
+    /// Highest block seen, so entries the chain has moved past can be dropped first.
+    newest_block_number: u64,
+    responses: HashMap<(u64, B256, Address, Bytes), Response>,
+    in_flight: HashMap<(u64, B256, Address, Bytes), Arc<InFlight>>,
+}
+
+#[derive(Debug, Default)]
+struct InFlight {
+    result: Mutex<Option<Result<Response, String>>>,
+    ready: Condvar,
+}
+
+/// Resolves read precompile calls that the chain head did not record by asking an upstream
+/// hl-node for them.
+pub struct ReadPrecompileForwarder {
+    client: HttpClient,
+    handle: Handle,
+    rate_limiter: Option<Arc<RequestRateLimiter>>,
+    /// Responses already fetched from the upstream.
+    ///
+    /// Repeated calls are the norm rather than the exception: `eth_estimateGas` binary searches
+    /// over the same transaction, re-running every precompile call on each iteration. Caching
+    /// also makes all reads within one RPC request agree with each other, which separate
+    /// upstream calls do not guarantee.
+    cache: Mutex<Cache>,
+}
+
+#[derive(Debug)]
+struct RequestRateLimiter {
+    period: Duration,
+    next_request: Mutex<Instant>,
+}
+
+impl RequestRateLimiter {
+    fn new(requests_per_second: NonZeroU32) -> Self {
+        let period = Duration::from_secs_f64(1.0 / f64::from(requests_per_second.get()));
+        Self { period, next_request: Mutex::new(Instant::now()) }
+    }
+
+    fn wait(&self) {
+        let now = Instant::now();
+        let scheduled = {
+            let mut next_request = self.next_request.lock();
+            let scheduled = (*next_request).max(now);
+            *next_request = scheduled + self.period;
+            scheduled
+        };
+        std::thread::sleep(scheduled.saturating_duration_since(now));
+    }
+}
+
+/// Summarises the cache rather than dumping it.
+///
+/// The execution context holds one of these and derives [`Debug`], so a derived impl here would
+/// print every cached response — up to [`MAX_CACHE_ENTRIES`] of them — into any log line or error
+/// that formats the context.
+impl std::fmt::Debug for ReadPrecompileForwarder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cache = self.cache.lock();
+        f.debug_struct("ReadPrecompileForwarder")
+            .field("newest_block_number", &cache.newest_block_number)
+            .field("cached_responses", &cache.responses.len())
+            .field("in_flight_requests", &cache.in_flight.len())
+            .field("rate_limited", &self.rate_limiter.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ReadPrecompileForwarder {
+    /// Creates a forwarder that resolves calls against `url`.
+    ///
+    /// `handle` drives the requests, since precompiles are invoked from blocking RPC workers.
+    pub fn new(
+        url: &str,
+        handle: Handle,
+        requests_per_second: Option<NonZeroU32>,
+    ) -> eyre::Result<Self> {
+        let client = HttpClientBuilder::default().request_timeout(REQUEST_TIMEOUT).build(url)?;
+        let rate_limiter = requests_per_second.map(|rate| Arc::new(RequestRateLimiter::new(rate)));
+        Ok(Self { client, handle, rate_limiter, cache: Mutex::new(Cache::default()) })
+    }
+
+    /// Runs `input` against the read precompile at `address` as of the chain head.
+    ///
+    /// `block_number` only scopes the cache. The upstream is always asked for `latest`, and there
+    /// is no point asking it for anything else: hl-node overrides the requested block with the
+    /// head, since HyperCore state is not archived. That is also why the forwarder is installed
+    /// for the head alone — a historical read precompile call can only be answered by replaying
+    /// the block's recorded calls.
+    pub fn call(
+        &self,
+        address: Address,
+        input: &[u8],
+        gas_limit: u64,
+        block_number: u64,
+        head_hash: B256,
+    ) -> PrecompileResult {
+        let input = Bytes::copy_from_slice(input);
+        match self.resolve(address, &input, block_number, head_hash)? {
+            Response::Output(bytes) => {
+                let gas_used = read_precompile_gas(input.len(), bytes.len());
+                if gas_used > gas_limit {
+                    return Err(PrecompileError::OutOfGas);
+                }
+                Ok(PrecompileOutput { gas_used, bytes, reverted: false })
+            }
+            // HL burns the whole gas limit when a read precompile rejects its input, which is
+            // also how `ReadPrecompileResult::Error` is replayed for recorded blocks.
+            Response::Rejected => Err(PrecompileError::OutOfGas),
+        }
+    }
+
+    fn resolve(
+        &self,
+        address: Address,
+        input: &Bytes,
+        block_number: u64,
+        head_hash: B256,
+    ) -> Result<Response, PrecompileError> {
+        let key = (block_number, head_hash, address, input.clone());
+
+        let (in_flight, leader) = {
+            let mut cache = self.cache.lock();
+            if let Some(cached) = cache.responses.get(&key) {
+                return Ok(cached.clone());
+            }
+            if let Some(in_flight) = cache.in_flight.get(&key) {
+                (in_flight.clone(), false)
+            } else {
+                let in_flight = Arc::new(InFlight::default());
+                cache.in_flight.insert(key.clone(), in_flight.clone());
+                (in_flight, true)
+            }
+        };
+
+        if !leader {
+            let mut result = in_flight.result.lock();
+            while result.is_none() {
+                in_flight.ready.wait(&mut result);
+            }
+            return result.clone().unwrap().map_err(PrecompileError::Fatal);
+        }
+
+        let result = self.request(address, input).map_err(|err| err.to_string());
+        let mut cache = self.cache.lock();
+        cache.in_flight.remove(&key);
+        if let Ok(response) = &result {
+            cache.newest_block_number = cache.newest_block_number.max(block_number);
+            if cache.responses.len() >= MAX_CACHE_ENTRIES {
+                // Drop what the chain has moved past first, so a burst of calls at the head does not
+                // throw away the entries it is still working through.
+                let newest = cache.newest_block_number;
+                cache.responses.retain(|(block, _, _, _), _| *block >= newest);
+                if cache.responses.len() >= MAX_CACHE_ENTRIES {
+                    cache.responses.clear();
+                }
+            }
+            cache.responses.insert(key, response.clone());
+        }
+        drop(cache);
+
+        *in_flight.result.lock() = Some(result.clone());
+        in_flight.ready.notify_all();
+        result.map_err(PrecompileError::Fatal)
+    }
+
+    fn request(&self, address: Address, input: &Bytes) -> Result<Response, PrecompileError> {
+        if let Some(rate_limiter) = &self.rate_limiter {
+            rate_limiter.wait();
+        }
+        let client = self.client.clone();
+        let params = rpc_params![serde_json::json!({ "to": address, "data": input }), "latest"];
+
+        // Precompiles are called from blocking RPC workers, so the request is driven on the
+        // node's runtime and waited on here rather than awaited.
+        let (tx, rx) = std::sync::mpsc::sync_channel(1);
+        self.handle.spawn(async move {
+            let _ = tx.send(client.request::<Bytes, _>("eth_call", params).await);
+        });
+
+        // The client times out on its own; this only guards against the response never arriving.
+        let result = rx.recv_timeout(REQUEST_TIMEOUT * 2).map_err(|_| {
+            warn!(target: "rpc::eth", %address, "Timed out forwarding read precompile call");
+            PrecompileError::Fatal(format!("read precompile {address} timed out"))
+        })?;
+
+        match result {
+            Ok(bytes) => Ok(Response::Output(bytes)),
+            Err(ClientError::Call(err)) if is_rejected_input(&err) => {
+                debug!(target: "rpc::eth", %address, message = err.message(), "Read precompile rejected input");
+                Ok(Response::Rejected)
+            }
+            Err(err) => {
+                warn!(target: "rpc::eth", %address, %err, "Failed to forward read precompile call");
+                Err(PrecompileError::Fatal(format!(
+                    "failed to forward read precompile {address}: {err}"
+                )))
+            }
+        }
+    }
+}
+
+/// JSON-RPC code hl-node answers a failed `eth_call` with.
+const EXECUTION_ERROR_CODE: i32 = -32003;
+
+/// Whether a JSON-RPC error means the upstream ran the precompile and it refused the input,
+/// rather than that the upstream could not serve the request at all.
+///
+/// Only the former burns the gas limit. Everything else — a wrong URL, a node without `eth_call`,
+/// a rate limit, an overloaded upstream — has to surface as an RPC error, because reporting it as
+/// a refused input would hand the caller a plausible but wrong out-of-gas result instead of a
+/// visible failure.
+///
+/// This deliberately matches on the message as well as the code. The codes EVM RPCs use for
+/// execution failures (`-32003`, and `-32000` in particular) double as generic server-error
+/// catch-alls, so matching the code alone is what lets a throttled response through as a refused
+/// input. Being too strict only costs a loud error where a quiet one would do.
+fn is_rejected_input(err: &ErrorObject<'_>) -> bool {
+    err.code() == EXECUTION_ERROR_CODE && err.message().contains("PrecompileError")
+}
+
+static FORWARDER: OnceLock<Arc<ReadPrecompileForwarder>> = OnceLock::new();
+
+/// Installs the process-wide forwarder used by the RPC call paths.
+pub fn set_read_precompile_forwarder(forwarder: ReadPrecompileForwarder) {
+    if FORWARDER.set(Arc::new(forwarder)).is_err() {
+        warn!(target: "rpc::eth", "Read precompile forwarder is already installed");
+    }
+}
+
+/// The installed forwarder, if `--forward-read-precompiles` was set.
+pub fn read_precompile_forwarder() -> Option<Arc<ReadPrecompileForwarder>> {
+    FORWARDER.get().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `(input_len, output_len, gas)` samples taken from mainnet by binary searching the minimum
+    /// gas limit that lets a direct `eth_call` to a read precompile succeed, minus the intrinsic
+    /// cost of the transaction. Covers `0x801`, `0x806`..`0x80a`, `0x80c` and `0x80e`.
+    const SAMPLES: [(usize, usize, u64); 6] = [
+        (0, 32, 2056),
+        (32, 32, 3112),
+        (32, 64, 4168),
+        (64, 96, 6280),
+        (32, 256, 10504),
+        (32, 384, 14728),
+    ];
+
+    #[test]
+    fn gas_matches_measured_samples() {
+        for (input_len, output_len, expected) in SAMPLES {
+            assert_eq!(
+                read_precompile_gas(input_len, output_len),
+                expected,
+                "input_len={input_len} output_len={output_len}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_a_refused_input_burns_gas() {
+        let err = |code, message: &str| ErrorObject::owned(code, message.to_string(), None::<()>);
+
+        // What hl-node answers a read precompile that refused its input with.
+        assert!(is_rejected_input(&err(EXECUTION_ERROR_CODE, "EVM error: PrecompileError")));
+
+        // Everything else has to surface as an error rather than as an out-of-gas result: an
+        // upstream that throttled or fell over never ran the precompile at all.
+        for (code, message) in [
+            (EXECUTION_ERROR_CODE, "rate limit exceeded"),
+            (-32000, "rate limited"),
+            (-32000, "execution timeout"),
+            (-32601, "method eth_call is not available"),
+            (-32603, "internal error"),
+            (
+                EXECUTION_ERROR_CODE,
+                "out of gas: gas exhausted during precompiled contract execution: 21000",
+            ),
+        ] {
+            assert!(!is_rejected_input(&err(code, message)), "{code} {message}");
+        }
+    }
+
+    #[test]
+    fn same_height_reorg_has_a_distinct_cache_key() {
+        let address = Address::repeat_byte(1);
+        let input = Bytes::from_static(&[2]);
+        let old_head = B256::repeat_byte(3);
+        let new_head = B256::repeat_byte(4);
+        let mut cache = Cache::default();
+
+        cache.responses.insert(
+            (10, old_head, address, input.clone()),
+            Response::Output(Bytes::from_static(&[5])),
+        );
+
+        assert!(!cache.responses.contains_key(&(10, new_head, address, input)));
+    }
+
+    /// `l1BlockNumber`, which takes no input and returns one word.
+    const L1_BLOCK_NUMBER: Address =
+        alloy_primitives::address!("0x0000000000000000000000000000000000000809");
+
+    /// `bbo`, the precompile whose unrecorded call made the `eth_call` in
+    /// <https://github.com/hl-archive-node/nanoreth/issues/142> revert, and the input it was
+    /// reached with there.
+    const BBO: Address = alloy_primitives::address!("0x000000000000000000000000000000000000080e");
+    const BBO_INPUT: [u8; 32] = alloy_primitives::hex!(
+        "0x000000000000000000000000000000000000000000000000000000000000277b"
+    );
+
+    /// Checks the whole round trip — request shape, error mapping and pricing — against a real
+    /// hl-node. Ignored by default because it needs network access.
+    ///
+    /// Run with `HL_RPC_URL=http://localhost:3001/evm cargo test -- --ignored forwards`.
+    #[tokio::test(flavor = "multi_thread")]
+    #[ignore = "requires network access to an hl-node RPC"]
+    async fn forwards_calls_to_an_hl_node() {
+        let url = std::env::var("HL_RPC_URL")
+            .unwrap_or_else(|_| "https://rpc.hyperliquid.xyz/evm".to_string());
+        let forwarder = ReadPrecompileForwarder::new(&url, Handle::current(), None).unwrap();
+
+        // Precompiles run on blocking workers, which is what the forwarder expects.
+        tokio::task::spawn_blocking(move || {
+            let head_hash = B256::repeat_byte(1);
+            let output = forwarder.call(L1_BLOCK_NUMBER, &[], 1_000_000, 1, head_hash).unwrap();
+            assert_eq!(output.bytes.len(), 32);
+            assert_eq!(output.gas_used, read_precompile_gas(0, 32));
+
+            // A gas limit one short of the cost is not enough to run the precompile.
+            assert!(matches!(
+                forwarder.call(L1_BLOCK_NUMBER, &[], output.gas_used - 1, 1, head_hash),
+                Err(PrecompileError::OutOfGas)
+            ));
+
+            // An input the precompile rejects burns the gas limit rather than returning bytes.
+            assert!(matches!(
+                forwarder.call(L1_BLOCK_NUMBER, &[0xde, 0xad], 1_000_000, 1, head_hash),
+                Err(PrecompileError::OutOfGas)
+            ));
+
+            // The frame that reverted in #142: a Multicall3 batch reached `bbo` on a block that
+            // had recorded no call to it. Priced at 4168 gas on mainnet, which is what a direct
+            // call to it costs.
+            let output = forwarder.call(BBO, &BBO_INPUT, 1_000_000, 1, head_hash).unwrap();
+            assert_eq!(output.bytes.len(), 64);
+            assert_eq!(output.gas_used, read_precompile_gas(BBO_INPUT.len(), 64));
+        })
+        .await
+        .unwrap();
+    }
+}

--- a/src/node/rpc/call.rs
+++ b/src/node/rpc/call.rs
@@ -1,38 +1,47 @@
 use core::fmt;
 
 use super::{HlEthApi, HlRpcNodeCore};
-use crate::{HlBlock, node::evm::apply_precompiles};
+use crate::{
+    HlBlock,
+    evm::transaction::HlTxEnvExt,
+    node::evm::{
+        apply_precompiles, apply_precompiles_with_forwarder,
+        read_precompile_forwarder::read_precompile_forwarder,
+    },
+};
 use alloy_consensus::transaction::TxHashRef;
-use alloy_evm::Evm;
+use alloy_evm::{
+    Evm, EvmFactory,
+    block::BlockExecutorFactory,
+    overrides::{OverrideBlockHashes, apply_block_overrides, apply_state_overrides},
+};
+use alloy_network::TransactionBuilder;
 use alloy_primitives::B256;
+use alloy_rpc_types_eth::state::EvmOverrides;
 use reth::rpc::server_types::eth::EthApiError;
-use reth_evm::{ConfigureEvm, Database, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TxEnvFor};
+use reth_evm::{
+    ConfigureEvm, Database, EvmEnvFor, HaltReasonFor, InspectorFor, SpecFor, TransactionEnv,
+    TxEnvFor,
+};
 use reth_primitives::{NodePrimitives, Recovered};
 use reth_provider::{ProviderError, ProviderTx};
-use reth_rpc_eth_api::{
-    FromEvmError, RpcConvert, RpcNodeCore,
-    helpers::{Call, EthCall},
+use reth_rpc_convert::RpcTxReq;
+use reth_rpc_eth_api::{FromEvmError, RpcConvert, RpcNodeCore, helpers::Call};
+use revm::{
+    Database as RevmDatabase, DatabaseCommit, context::result::ResultAndState,
+    context_interface::Transaction,
 };
-use revm::{DatabaseCommit, context::result::ResultAndState};
+use tracing::{trace, warn};
 
 impl<N> HlRpcNodeCore for N where N: RpcNodeCore<Primitives: NodePrimitives<Block = HlBlock>> {}
 
-impl<N, Rpc> EthCall for HlEthApi<N, Rpc>
-where
-    N: HlRpcNodeCore,
-    EthApiError: FromEvmError<N::Evm>,
-    Rpc: RpcConvert<
-            Primitives = N::Primitives,
-            Error = EthApiError,
-            TxEnv = TxEnvFor<N::Evm>,
-            Spec = SpecFor<N::Evm>,
-        >,
-{
-}
-
 impl<N, Rpc> Call for HlEthApi<N, Rpc>
 where
-    N: HlRpcNodeCore,
+    N: HlRpcNodeCore<
+        Evm: ConfigureEvm<
+            BlockExecutorFactory: BlockExecutorFactory<EvmFactory: EvmFactory<Tx: HlTxEnvExt>>,
+        >,
+    >,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<
             Primitives = N::Primitives,
@@ -60,11 +69,12 @@ where
     where
         DB: Database<Error = ProviderError> + fmt::Debug,
     {
-        let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
+        let block_number =
+            tx_env.rpc_state_block_number().unwrap_or(evm_env.block_env().number.to());
+        let (hl_extras, forwarder) = self.hl_call_precompiles(block_number)?;
 
         let mut evm = self.evm_config().evm_with_env(db, evm_env);
-        apply_precompiles(&mut evm, &hl_extras);
+        apply_precompiles_with_forwarder(&mut evm, &hl_extras, forwarder);
         let res = evm.transact(tx_env).map_err(Self::Error::from_evm_err)?;
 
         Ok(res)
@@ -81,11 +91,12 @@ where
         DB: Database<Error = ProviderError> + fmt::Debug,
         I: InspectorFor<Self::Evm, DB>,
     {
-        let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
+        let block_number =
+            tx_env.rpc_state_block_number().unwrap_or(evm_env.block_env().number.to());
+        let (hl_extras, forwarder) = self.hl_call_precompiles(block_number)?;
 
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
-        apply_precompiles(&mut evm, &hl_extras);
+        apply_precompiles_with_forwarder(&mut evm, &hl_extras, forwarder);
         let res = evm.transact(tx_env).map_err(Self::Error::from_evm_err)?;
 
         Ok(res)
@@ -120,5 +131,61 @@ where
             index += 1;
         }
         Ok(index)
+    }
+
+    fn prepare_call_env<DB>(
+        &self,
+        mut evm_env: EvmEnvFor<Self::Evm>,
+        mut request: RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>,
+        db: &mut DB,
+        overrides: EvmOverrides,
+    ) -> Result<(EvmEnvFor<Self::Evm>, TxEnvFor<Self::Evm>), Self::Error>
+    where
+        DB: RevmDatabase + DatabaseCommit + OverrideBlockHashes,
+        EthApiError: From<<DB as RevmDatabase>::Error>,
+    {
+        let rpc_state_block_number = evm_env.block_env.number.to();
+        let request_has_gas_limit = request.as_ref().gas_limit().is_some();
+
+        if let Some(requested_gas) = request.as_ref().gas_limit() {
+            let global_gas_cap = self.call_gas_limit();
+            if global_gas_cap != 0 && global_gas_cap < requested_gas {
+                warn!(target: "rpc::eth::call", ?request, ?global_gas_cap, "Capping gas limit to global gas cap");
+                request.as_mut().set_gas_limit(global_gas_cap);
+            }
+        } else {
+            request.as_mut().set_gas_limit(self.call_gas_limit());
+        }
+
+        evm_env.cfg_env.disable_block_gas_limit = true;
+        evm_env.cfg_env.disable_eip3607 = true;
+        evm_env.cfg_env.disable_base_fee = true;
+        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+        request.as_mut().take_nonce();
+
+        if let Some(block_overrides) = overrides.block {
+            apply_block_overrides(*block_overrides, db, &mut evm_env.block_env);
+        }
+        if let Some(state_overrides) = overrides.state {
+            apply_state_overrides(state_overrides, db)
+                .map_err(EthApiError::from_state_overrides_err)?;
+        }
+
+        let mut tx_env = self.create_txn_env(&evm_env, request, &mut *db)?;
+        if read_precompile_forwarder().is_some() {
+            tx_env.set_rpc_state_block_number(rpc_state_block_number);
+        }
+
+        if tx_env.gas_price() == 0 {
+            evm_env.block_env.basefee = 0;
+        }
+
+        if !request_has_gas_limit && tx_env.gas_price() > 0 {
+            trace!(target: "rpc::eth::call", ?tx_env, "Applying gas limit cap with caller allowance");
+            let cap = self.caller_gas_allowance(db, &evm_env, &tx_env)?;
+            tx_env.set_gas_limit(cap.min(evm_env.block_env.gas_limit));
+        }
+
+        Ok((evm_env, tx_env))
     }
 }

--- a/src/node/rpc/estimate.rs
+++ b/src/node/rpc/estimate.rs
@@ -1,4 +1,4 @@
-use super::{HlEthApi, HlRpcNodeCore, apply_precompiles};
+use super::{HlEthApi, HlRpcNodeCore, apply_precompiles_with_forwarder};
 use alloy_evm::overrides::{StateOverrideError, apply_state_overrides};
 use alloy_network::TransactionBuilder;
 use alloy_primitives::{TxKind, U256};
@@ -97,10 +97,10 @@ where
         tx_env.set_gas_limit(tx_env.gas_limit().min(highest_gas_limit));
 
         let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
+        let (hl_extras, forwarder) = self.hl_call_precompiles(block_number.to())?;
 
         let mut evm = self.evm_config().evm_with_env(&mut db, evm_env);
-        apply_precompiles(&mut evm, &hl_extras);
+        apply_precompiles_with_forwarder(&mut evm, &hl_extras, forwarder);
 
         if is_basic_transfer {
             let mut min_tx_env = tx_env.clone();

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -1,11 +1,18 @@
 use crate::{
     HlBlock, HlPrimitives,
     chainspec::HlChainSpec,
-    node::{evm::apply_precompiles, types::HlExtras},
+    evm::transaction::HlTxEnvExt,
+    node::{
+        evm::{
+            ScopedReadPrecompileForwarder, apply_precompiles, apply_precompiles_with_forwarder,
+            read_precompile_forwarder::read_precompile_forwarder,
+        },
+        types::HlExtras,
+    },
 };
 use alloy_consensus::{BlockHeader, transaction::TxHashRef};
 use alloy_eips::BlockId;
-use alloy_evm::{Evm, EvmFactory};
+use alloy_evm::{Evm, EvmFactory, block::BlockExecutorFactory};
 use alloy_network::Ethereum;
 use alloy_primitives::U256;
 use alloy_rpc_types_eth::TransactionInfo;
@@ -47,15 +54,16 @@ use reth_rpc_eth_api::{
     },
 };
 use reth_rpc_eth_types::cache::db::{StateCacheDbRefMutWrapper, StateProviderTraitObjWrapper};
-use reth_storage_api::ProviderBlock;
+use reth_storage_api::{BlockNumReader, ProviderBlock};
 use revm::{DatabaseCommit, context::result::ResultAndState};
-use std::{fmt, marker::PhantomData, sync::Arc};
+use std::{cmp::Ordering, fmt, marker::PhantomData, sync::Arc};
 
 mod block;
 mod call;
 pub mod engine_api;
 mod estimate;
 pub mod precompile;
+mod simulate;
 mod transaction;
 
 pub trait HlRpcNodeCore: RpcNodeCore<Primitives: NodePrimitives<Block = HlBlock>> {}
@@ -234,7 +242,11 @@ where
 
 impl<N, Rpc> Trace for HlEthApi<N, Rpc>
 where
-    N: HlRpcNodeCore,
+    N: HlRpcNodeCore<
+        Evm: ConfigureEvm<
+            BlockExecutorFactory: BlockExecutorFactory<EvmFactory: EvmFactory<Tx: HlTxEnvExt>>,
+        >,
+    >,
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
@@ -249,11 +261,12 @@ where
         DB: Database<Error = ProviderError>,
         I: InspectorFor<Self::Evm, DB>,
     {
-        let block_number = evm_env.block_env().number;
-        let hl_extras = self.get_hl_extras(block_number.to::<u64>().into())?;
+        let block_number =
+            tx_env.rpc_state_block_number().unwrap_or(evm_env.block_env().number.to());
+        let (hl_extras, forwarder) = self.hl_call_precompiles(block_number)?;
 
         let mut evm = self.evm_config().evm_with_env_and_inspector(db, evm_env, inspector);
-        apply_precompiles(&mut evm, &hl_extras);
+        apply_precompiles_with_forwarder(&mut evm, &hl_extras, forwarder);
         evm.transact(tx_env).map_err(Self::Error::from_evm_err)
     }
 
@@ -372,6 +385,76 @@ where
                 highest_precompile_address: block.body.highest_precompile_address,
             })
             .unwrap_or_default())
+    }
+
+    /// Read precompile data to run a call at `block_number` with.
+    ///
+    /// Alongside the block's recorded calls this returns the forwarder to resolve unrecorded
+    /// inputs with, but only from the chain head onwards: HyperCore state is not archived, so
+    /// forwarding a historical call would answer it with today's values.
+    fn hl_call_precompiles(
+        &self,
+        block_number: u64,
+    ) -> Result<(HlExtras, Option<ScopedReadPrecompileForwarder>), ProviderError> {
+        let Some(forwarder) = read_precompile_forwarder() else {
+            return Ok((self.get_hl_extras(block_number.into())?, None));
+        };
+
+        let chain_info = self.provider().chain_info()?;
+        let best_block_number = chain_info.best_number;
+        let forwarder = Some((forwarder, chain_info.best_hash));
+
+        match block_number.cmp(&best_block_number) {
+            Ordering::Less => Ok((self.get_hl_extras(block_number.into())?, None)),
+            Ordering::Equal => Ok((self.get_hl_extras(block_number.into())?, forwarder)),
+            // A block that has not been mined has no body to take the precompile address range
+            // from, so borrow the head's. Without this the range falls back to `0x800..=0x80d`
+            // and everything above it — `bbo` and up — is left uninstalled, so reading one looks
+            // like a call to a plain account rather than a precompile.
+            //
+            // Its recorded calls are left out: those belong to the head block's own transactions,
+            // and the forwarder answers the same inputs anyway.
+            Ordering::Greater => {
+                let head = self.get_hl_extras(best_block_number.into())?;
+                Ok((
+                    HlExtras {
+                        read_precompile_calls: None,
+                        highest_precompile_address: head.highest_precompile_address,
+                    },
+                    forwarder,
+                ))
+            }
+        }
+    }
+
+    /// Read precompile data for blocks simulated on top of `parent_block_number`.
+    ///
+    /// A simulated block has no canonical body, so it must never borrow recorded calls from the
+    /// canonical block at the same height. It only inherits the parent's precompile address range.
+    /// Forwarding is available when the simulation starts at the head, where the upstream's
+    /// `latest` HyperCore state matches the local state being simulated.
+    fn hl_simulation_precompiles(
+        &self,
+        parent_block_number: u64,
+    ) -> Result<(HlExtras, Option<ScopedReadPrecompileForwarder>), ProviderError> {
+        let Some(forwarder) = read_precompile_forwarder() else {
+            return Ok((HlExtras::default(), None));
+        };
+
+        let chain_info = self.provider().chain_info()?;
+        let best_block_number = chain_info.best_number;
+        let extras_block_number = parent_block_number.min(best_block_number);
+        let parent = self.get_hl_extras(extras_block_number.into())?;
+        let forwarder =
+            (parent_block_number >= best_block_number).then_some((forwarder, chain_info.best_hash));
+
+        Ok((
+            HlExtras {
+                read_precompile_calls: None,
+                highest_precompile_address: parent.highest_precompile_address,
+            },
+            forwarder,
+        ))
     }
 }
 

--- a/src/node/rpc/simulate.rs
+++ b/src/node/rpc/simulate.rs
@@ -1,0 +1,214 @@
+use super::{HlEthApi, HlRpcNodeCore};
+use crate::{HlHeader, evm::transaction::HlTxEnvExt, node::evm::config::HlBlockExecutionCtx};
+use alloy_eips::BlockId;
+use alloy_evm::{
+    EvmFactory,
+    overrides::{StateOverrideError, apply_block_overrides, apply_state_overrides},
+};
+use alloy_network::TransactionBuilder;
+use alloy_rpc_types_eth::simulate::{SimBlock, SimulatePayload, SimulatedBlock};
+use reth_errors::{ProviderError, RethError};
+use reth_evm::{ConfigureEvm, SpecFor, TxEnvFor, block::BlockExecutorFactory};
+use reth_primitives::NodePrimitives;
+use reth_revm::{database::StateProviderDatabase, db::State};
+use reth_rpc_convert::{RpcConvert, RpcTxReq};
+use reth_rpc_eth_api::{
+    EthApiTypes, FromEvmError, RpcBlock, RpcNodeCore,
+    helpers::{Call, EthCall, LoadBlock, LoadPendingBlock, call::SimulatedBlocksResult},
+};
+use reth_rpc_eth_types::{
+    EthApiError,
+    simulate::{self, EthSimulateError},
+};
+use revm_inspectors::transfer::TransferInspector;
+use std::future::Future;
+
+impl<N, Rpc> EthCall for HlEthApi<N, Rpc>
+where
+    N: HlRpcNodeCore<
+            Primitives: NodePrimitives<BlockHeader = HlHeader>,
+            Evm: ConfigureEvm<
+                BlockExecutorFactory: for<'a> BlockExecutorFactory<
+                    ExecutionCtx<'a> = HlBlockExecutionCtx<'a>,
+                    EvmFactory: EvmFactory<Tx: HlTxEnvExt>,
+                >,
+            >,
+        >,
+    EthApiError: FromEvmError<N::Evm>,
+    Rpc: RpcConvert<
+            Primitives = N::Primitives,
+            Error = EthApiError,
+            TxEnv = TxEnvFor<N::Evm>,
+            Spec = SpecFor<N::Evm>,
+        >,
+{
+    /// Copy of reth's default `simulate_v1`, with the read precompile data attached to the
+    /// execution context; comments are stripped out.
+    ///
+    /// Simulation runs through the block builder rather than through [`Call::transact`], so it
+    /// picks up its precompiles from [`HlBlockExecutionCtx`] instead. That context is built by
+    /// `context_for_next_block`, which has no provider to look the head up with and so leaves the
+    /// precompile address range empty — without this override, the precompiles above the default
+    /// `0x80d` (`bbo` and up) are not installed at all and simulating a call that reads them
+    /// fails as though they were plain accounts.
+    ///
+    /// [`HlBlockExecutionCtx`]: crate::node::evm::config::HlBlockExecutionCtx
+    // The trait declares this as `-> impl Future + Send`, which `async fn` would not reproduce.
+    #[allow(clippy::manual_async_fn)]
+    fn simulate_v1(
+        &self,
+        payload: SimulatePayload<RpcTxReq<<Self::RpcConvert as RpcConvert>::Network>>,
+        block: Option<BlockId>,
+    ) -> impl Future<Output = SimulatedBlocksResult<Self::NetworkTypes, Self::Error>> + Send {
+        async move {
+            if payload.block_state_calls.len() > self.max_simulate_blocks() as usize {
+                return Err(EthApiError::InvalidParams("too many blocks.".to_string()));
+            }
+
+            let block = block.unwrap_or_default();
+
+            let SimulatePayload {
+                block_state_calls,
+                trace_transfers,
+                validation,
+                return_full_transactions,
+            } = payload;
+
+            if block_state_calls.is_empty() {
+                return Err(EthApiError::InvalidParams(String::from("calls are empty.")));
+            }
+
+            let base_block =
+                self.recovered_block(block).await?.ok_or(EthApiError::HeaderNotFound(block))?;
+            let mut parent = base_block.sealed_header().clone();
+            let simulation_precompiles =
+                if crate::node::evm::read_precompile_forwarder::read_precompile_forwarder()
+                    .is_some()
+                {
+                    Some(self.hl_simulation_precompiles(parent.number)?)
+                } else {
+                    None
+                };
+
+            let this = self.clone();
+            self.spawn_with_state_at_block(block, move |state| {
+                let mut db =
+                    State::builder().with_database(StateProviderDatabase::new(state)).build();
+                let mut blocks: Vec<SimulatedBlock<RpcBlock<Self::NetworkTypes>>> =
+                    Vec::with_capacity(block_state_calls.len());
+                for block in block_state_calls {
+                    let mut evm_env = this
+                        .evm_config()
+                        .next_evm_env(&parent, &this.next_env_attributes(&parent)?)
+                        .map_err(RethError::other)
+                        .map_err(<EthApiError as From<RethError>>::from)?;
+
+                    evm_env.cfg_env.disable_eip3607 = true;
+
+                    if !validation {
+                        evm_env.cfg_env.disable_nonce_check = true;
+                        evm_env.cfg_env.disable_base_fee = true;
+                        evm_env.cfg_env.tx_gas_limit_cap = Some(u64::MAX);
+                        evm_env.block_env.basefee = 0;
+                    }
+
+                    let SimBlock { block_overrides, state_overrides, calls } = block;
+
+                    if let Some(block_overrides) = block_overrides {
+                        if let Some(gas_limit_override) = block_overrides.gas_limit
+                            && gas_limit_override > evm_env.block_env.gas_limit
+                            && gas_limit_override > this.call_gas_limit()
+                        {
+                            return Err(EthApiError::other(
+                                EthSimulateError::GasLimitReached,
+                            ));
+                        }
+                        apply_block_overrides(block_overrides, &mut db, &mut evm_env.block_env);
+                    }
+                    if let Some(state_overrides) = state_overrides {
+                        apply_state_overrides(state_overrides, &mut db).map_err(
+                            <EthApiError as From<StateOverrideError<ProviderError>>>::from,
+                        )?;
+                    }
+
+                    let block_gas_limit = evm_env.block_env.gas_limit;
+                    let chain_id = evm_env.cfg_env.chain_id;
+
+                    let default_gas_limit = {
+                        let total_specified_gas =
+                            calls.iter().filter_map(|tx| tx.as_ref().gas_limit()).sum::<u64>();
+                        let txs_without_gas_limit =
+                            calls.iter().filter(|tx| tx.as_ref().gas_limit().is_none()).count();
+
+                        if total_specified_gas > block_gas_limit {
+                            return Err(EthApiError::Other(Box::new(
+                                EthSimulateError::BlockGasLimitExceeded,
+                            )));
+                        }
+
+                        if txs_without_gas_limit > 0 {
+                            (block_gas_limit - total_specified_gas) / txs_without_gas_limit as u64
+                        } else {
+                            0
+                        }
+                    };
+
+                    let mut ctx = this
+                        .evm_config()
+                        .context_for_next_block(&parent, this.next_env_attributes(&parent)?)
+                        .map_err(RethError::other)
+                        .map_err(<EthApiError as From<RethError>>::from)?;
+
+                    // The only part that differs from reth: attach the read precompile address
+                    // range inherited from the base block and, for head simulations, a forwarder.
+                    // Simulated blocks must not borrow recorded calls from canonical blocks that
+                    // happen to occupy the same heights.
+                    if let Some((simulation_extras, simulation_forwarder)) = &simulation_precompiles
+                    {
+                        ctx.extras = simulation_extras.clone();
+                        ctx.enable_rpc_read_precompile_forwarding(simulation_forwarder.clone());
+                    }
+
+                    let (result, results) = if trace_transfers {
+                        let inspector = TransferInspector::new(false).with_logs(true);
+                        let evm = this
+                            .evm_config()
+                            .evm_with_env_and_inspector(&mut db, evm_env, inspector);
+                        let builder = this.evm_config().create_block_builder(evm, &parent, ctx);
+                        simulate::execute_transactions(
+                            builder,
+                            calls,
+                            default_gas_limit,
+                            chain_id,
+                            this.tx_resp_builder(),
+                        )?
+                    } else {
+                        let evm = this.evm_config().evm_with_env(&mut db, evm_env);
+                        let builder = this.evm_config().create_block_builder(evm, &parent, ctx);
+                        simulate::execute_transactions(
+                            builder,
+                            calls,
+                            default_gas_limit,
+                            chain_id,
+                            this.tx_resp_builder(),
+                        )?
+                    };
+
+                    parent = result.block.clone_sealed_header();
+
+                    let block = simulate::build_simulated_block(
+                        result.block,
+                        results,
+                        return_full_transactions.into(),
+                        this.tx_resp_builder(),
+                    )?;
+
+                    blocks.push(block);
+                }
+
+                Ok(blocks)
+            })
+            .await
+        }
+    }
+}


### PR DESCRIPTION
Closes #26.

Blocks record only the read precompile calls their own transactions made, so `eth_call`,
`eth_estimateGas` and `debug_traceCall` against the head fail with out-of-gas the moment they
touch HyperCore state no transaction has read yet — which is what a wallet does when it estimates
gas. `--forward-call` avoids this by handing the whole call upstream, giving up state overrides
and tracing.

`--forward-read-precompiles` keeps execution local and forwards only the unrecorded read
precompile inputs, to `--read-precompile-rpc-url` (defaults to `--upstream-rpc-url`). Off by
default: without the flag nothing changes and no request is made.

Historical blocks are untouched. HyperCore state is not archived, and hl-node overrides a
requested block with the head, so a historical call can only be answered by replaying what the
block recorded.

## Gas

hl-node does not report a read precompile's gas over `eth_call`, but it turns out to be a pure
function of the payload sizes:

```
gas_used = 1000 + 33 * (input_len + output_len)
```

so the forwarder fetches only the output bytes and prices the result locally, deciding
out-of-gas against the real gas limit. The constants were measured by binary searching the
minimum gas that lets a direct call to each precompile succeed on mainnet, then confirmed against
a full node.

## Two commits

1. **`feat(rpc): resolve read precompiles …`** — the feature. No behaviour change without the flag.
2. **`fix(rpc): install HL read precompiles for eth_simulateV1`** — a pre-existing bug, worth
   reviewing separately because it changes behaviour with the flag off. `eth_simulateV1` builds a
   block rather than going through `Call::transact`, so its precompiles come from
   `HlBlockExecutionCtx`, which `context_for_next_block` leaves empty. The address range then fell
   back to `0x800..=0x80d`, leaving `bbo` and everything above it uninstalled — a read of one
   failed as though it were a plain account. Also adds `revm-inspectors` as a direct dependency
   (`TransferInspector`, for simulate's `traceTransfers`).

## Verification

Against a June 2026 mainnet archive snapshot (head 37,692,944), with the flag on and pointed at
the public RPC:

| check | flag off | flag on |
|---|---|---|
| `eth_call` bbo | out of gas | matches the full node byte for byte |
| `eth_estimateGas` bbo | out of gas | `0x643d` — identical to the full node |
| `eth_call`, the Multicall3 batch from #142 | `Multicall3: call failed` | succeeds |
| `debug_traceCall` / `trace_call` | frame records out of gas | returns data |
| `eth_simulateV1` bbo / multicall | `status 0x0` | `status 0x1` |
| `eth_call` at head−1000 | out of gas | out of gas (unchanged) |

`eth_estimateGas` matches the full node exactly for `0x801`, `0x806`, `0x808`, `0x809`, `0x80a`,
`0x80c` and `0x80e` — input 0–32 B, output 32–384 B. Inside the #142 multicall every `0x80e`
frame is charged exactly 4168 gas, the formula's value.

**Block execution is unaffected.** Replaying 56 user transactions across 12 blocks (38 recorded
precompile calls) with forwarding enabled reproduces every stored receipt's `gasUsed` exactly.
The forwarder is carried on the execution context and left `None` for real blocks, so the
invariant is structural rather than a property of the call path.

## Known gaps

- **One unexplained number.** `eth_estimateGas` for the #142 multicall returns 399,080 locally
  against 382,514 from the full node. The precompile frames are exactly right and all 37
  contracts involved have identical code at both heads, so this is in non-precompile execution —
  but the snapshot and the full node are 1.1M blocks apart and hl-node rewrites the requested
  block to the head, so there is no way to compare them at the same state. Left unexplained
  rather than guessed at.
- **Rate limits.** The public RPC sustains about **10 read precompile `eth_call`/s**; past that it
  returns JSON-RPC `-32005 "rate limited"` (and HTTP 429 for bursts — `eth_call` is weighted far
  more heavily than `eth_blockNumber`). Responses are cached per `(block, address, input)`, so a
  call issuing 8 precompile reads over 2 distinct inputs costs 2 upstream requests, and
  `eth_estimateGas`'s binary search costs nothing extra. Still, a busy node wants a local
  hl-node; the node logs a warning at startup when the forwarder resolves to the official RPC.
- **Batching is not implemented.** Precompiles are invoked one at a time and the EVM blocks on
  each, so there is nothing to batch within a pass. Doing it needs the two-pass replay sketched in
  #26 (placeholder pass to collect the input set, one batched fetch, re-run against the primed
  cache), which would also give the atomic snapshot that issue asks for. Worth a follow-up rather
  than folding in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
