### PR TITLE
fix(tracer): suppress phantom selfdestruct frames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1933,7 +1933,7 @@ dependencies = [
  "bitflags 2.9.2",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -1951,7 +1951,7 @@ dependencies = [
  "bitflags 2.9.2",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "regex",
@@ -4290,7 +4290,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5091,7 +5091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -9560,8 +9560,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b329afcc0f9fd5adfa2c6349a7435a8558e82bcae203142103a9a95e2a63b6"
+source = "git+https://github.com/hl-archive-node/revm-inspectors?rev=c6cade77bbb8a72d3709cd106faebf7663982ad6#c6cade77bbb8a72d3709cd106faebf7663982ad6"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -11855,7 +11854,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,6 +200,7 @@ revm-database = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b1
 revm-database-interface = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-handler = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-inspector = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
+revm-inspectors = { git = "https://github.com/hl-archive-node/revm-inspectors", rev = "c6cade77bbb8a72d3709cd106faebf7663982ad6" }
 revm-interpreter = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-precompile = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-primitives = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -90,6 +90,26 @@ echo "$TRACE_RESULT" | jq -e \
     ' > /dev/null \
     && success "$TITLE" || fail "$TITLE - trace_block missing expected tx hashes"
 
+TITLE="SELFDESTRUCT no-op must not produce phantom traces"
+SELFDESTRUCT_TX=0xf6267312b72427da6b27d3b8e6dd7e30cd5b434ab591f0f9acf6832541ed3fc2
+for REQUEST in \
+    "debug_traceTransaction:[\"$SELFDESTRUCT_TX\",{\"tracer\":\"callTracer\"}]" \
+    "trace_replayTransaction:[\"$SELFDESTRUCT_TX\",[\"trace\",\"stateDiff\"]]" \
+    ; do
+    METHOD=${REQUEST%%:*}
+    PARAMS=${REQUEST#*:}
+    RESULT=$(curl -sS -H 'content-type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$METHOD\",\"params\":$PARAMS}" \
+        "$TRACE_RPC_URL")
+    echo "$RESULT" | jq -e '
+        (.error | not) and has("result") and
+        ([.. | objects | .type? | strings | ascii_downcase |
+            select(. == "selfdestruct" or . == "suicide")] | length == 0)
+        ' > /dev/null \
+        || fail "$TITLE - $METHOD returned a phantom SELFDESTRUCT: $RESULT"
+done
+success "$TITLE"
+
 TITLE="Issue #143 - unknown/unavailable blocks must return null instead of panicking"
 UNKNOWN_HASH=0x1111111111111111111111111111111111111111111111111111111111111111
 FUTURE_BLOCK=0x7fffffffff


### PR DESCRIPTION
## Summary
- pin `revm-inspectors` to the compatibility fix in `hl-archive-node/revm-inspectors`
- require actual SELFDESTRUCT callback metadata before callTracer or parity builders emit a SELFDESTRUCT frame
- retain the existing singular `revm-inspector` journal-boundary fix
- add an RPC regression for the affected transaction to `tests/run_tests.sh`

## Root cause
Post-Cancun SELFDESTRUCT-to-self can halt with `InstructionResult::SelfDestruct` without changing state or emitting an inspector callback. `revm-inspectors` 0.30.0 nevertheless inferred a trace action from that status and filled the frame with default metadata.

## Validation
- regression test in the patched `revm-inspectors` fork
- `bash -n tests/run_tests.sh`
- jq assertion checked against clean and nested-SELFDESTRUCT fixtures
- `cargo check --locked --bin reth-hl`