### PR TITLE
fix(tracing): apply canonical post-transaction patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,8 +241,7 @@ dependencies = [
 [[package]]
 name = "alloy-evm"
 version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06a5f67ee74999aa4fe576a83be1996bdf74a30fce3d248bf2007d6fc7dae8aa"
+source = "git+https://github.com/hl-archive-node/alloy-evm?rev=9223654e84fe9e5c36295907f580cbd598f7e961#9223654e84fe9e5c36295907f580cbd598f7e961"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6744,7 +6743,7 @@ checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 [[package]]
 name = "reth"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-rpc-types",
  "aquamarine",
@@ -6790,7 +6789,7 @@ dependencies = [
 [[package]]
 name = "reth-basic-payload-builder"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6814,7 +6813,7 @@ dependencies = [
 [[package]]
 name = "reth-chain-state"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -6845,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "reth-chainspec"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6865,7 +6864,7 @@ dependencies = [
 [[package]]
 name = "reth-cli"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-genesis",
  "clap",
@@ -6879,7 +6878,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-commands"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -6960,7 +6959,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-runner"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "reth-tasks",
  "tokio",
@@ -6970,7 +6969,7 @@ dependencies = [
 [[package]]
 name = "reth-cli-util"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -6988,7 +6987,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7008,7 +7007,7 @@ dependencies = [
 [[package]]
 name = "reth-codecs-derive"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "convert_case",
  "proc-macro2",
@@ -7019,7 +7018,7 @@ dependencies = [
 [[package]]
 name = "reth-config"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "eyre",
  "humantime-serde",
@@ -7034,7 +7033,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7047,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-common"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7059,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "reth-consensus-debug-client"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7085,7 +7084,7 @@ dependencies = [
 [[package]]
 name = "reth-db"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "derive_more",
@@ -7111,7 +7110,7 @@ dependencies = [
 [[package]]
 name = "reth-db-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7139,7 +7138,7 @@ dependencies = [
 [[package]]
 name = "reth-db-common"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
@@ -7169,7 +7168,7 @@ dependencies = [
 [[package]]
 name = "reth-db-models"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7184,7 +7183,7 @@ dependencies = [
 [[package]]
 name = "reth-discv4"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7210,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "reth-discv5"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -7234,7 +7233,7 @@ dependencies = [
 [[package]]
 name = "reth-dns-discovery"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "data-encoding",
@@ -7258,7 +7257,7 @@ dependencies = [
 [[package]]
 name = "reth-downloaders"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7288,7 +7287,7 @@ dependencies = [
 [[package]]
 name = "reth-ecies"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "aes",
  "alloy-primitives",
@@ -7319,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-local"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7341,7 +7340,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7366,7 +7365,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-service"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "futures",
  "pin-project",
@@ -7389,7 +7388,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-tree"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7438,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "reth-engine-util"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -7466,7 +7465,7 @@ dependencies = [
 [[package]]
 name = "reth-era"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7482,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "reth-era-downloader"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "bytes",
@@ -7497,7 +7496,7 @@ dependencies = [
 [[package]]
 name = "reth-era-utils"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7519,7 +7518,7 @@ dependencies = [
 [[package]]
 name = "reth-errors"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "reth-consensus",
  "reth-execution-errors",
@@ -7530,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-chains",
  "alloy-primitives",
@@ -7559,7 +7558,7 @@ dependencies = [
 [[package]]
 name = "reth-eth-wire-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -7583,7 +7582,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-cli"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "clap",
  "eyre",
@@ -7605,7 +7604,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-consensus"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7621,7 +7620,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-engine-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7639,7 +7638,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-forks"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
@@ -7653,7 +7652,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-payload-builder"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7682,7 +7681,7 @@ dependencies = [
 [[package]]
 name = "reth-ethereum-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7702,7 +7701,7 @@ dependencies = [
 [[package]]
 name = "reth-etl"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "rayon",
  "reth-db-api",
@@ -7712,7 +7711,7 @@ dependencies = [
 [[package]]
 name = "reth-evm"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7735,7 +7734,7 @@ dependencies = [
 [[package]]
 name = "reth-evm-ethereum"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7756,7 +7755,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-errors"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-evm",
  "alloy-primitives",
@@ -7769,7 +7768,7 @@ dependencies = [
 [[package]]
 name = "reth-execution-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7787,7 +7786,7 @@ dependencies = [
 [[package]]
 name = "reth-exex"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -7825,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "reth-exex-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -7839,7 +7838,7 @@ dependencies = [
 [[package]]
 name = "reth-fs-util"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "serde",
  "serde_json",
@@ -7849,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "reth-invalid-block-hooks"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -7876,7 +7875,7 @@ dependencies = [
 [[package]]
 name = "reth-ipc"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "bytes",
  "futures",
@@ -7896,7 +7895,7 @@ dependencies = [
 [[package]]
 name = "reth-libmdbx"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "bitflags 2.9.2",
  "byteorder",
@@ -7912,7 +7911,7 @@ dependencies = [
 [[package]]
 name = "reth-mdbx-sys"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -7921,7 +7920,7 @@ dependencies = [
 [[package]]
 name = "reth-metrics"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "futures",
  "metrics",
@@ -7933,7 +7932,7 @@ dependencies = [
 [[package]]
 name = "reth-net-banlist"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
 ]
@@ -7941,7 +7940,7 @@ dependencies = [
 [[package]]
 name = "reth-net-nat"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "futures-util",
  "if-addrs",
@@ -7955,7 +7954,7 @@ dependencies = [
 [[package]]
 name = "reth-network"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8010,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "reth-network-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8035,7 +8034,7 @@ dependencies = [
 [[package]]
 name = "reth-network-p2p"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8057,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "reth-network-peers"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -8072,7 +8071,7 @@ dependencies = [
 [[package]]
 name = "reth-network-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eip2124",
  "humantime-serde",
@@ -8086,7 +8085,7 @@ dependencies = [
 [[package]]
 name = "reth-nippy-jar"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "anyhow",
  "bincode",
@@ -8103,7 +8102,7 @@ dependencies = [
 [[package]]
 name = "reth-node-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-rpc-types-engine",
  "eyre",
@@ -8127,7 +8126,7 @@ dependencies = [
 [[package]]
 name = "reth-node-builder"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8195,7 +8194,7 @@ dependencies = [
 [[package]]
 name = "reth-node-core"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8247,7 +8246,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethereum"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-network",
@@ -8285,7 +8284,7 @@ dependencies = [
 [[package]]
 name = "reth-node-ethstats"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8309,7 +8308,7 @@ dependencies = [
 [[package]]
 name = "reth-node-events"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8333,7 +8332,7 @@ dependencies = [
 [[package]]
 name = "reth-node-metrics"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "eyre",
  "http 1.3.1",
@@ -8354,7 +8353,7 @@ dependencies = [
 [[package]]
 name = "reth-node-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "reth-chainspec",
  "reth-db-api",
@@ -8366,7 +8365,7 @@ dependencies = [
 [[package]]
 name = "reth-optimism-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8385,7 +8384,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8406,7 +8405,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-builder-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "pin-project",
  "reth-payload-primitives",
@@ -8418,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8438,7 +8437,7 @@ dependencies = [
 [[package]]
 name = "reth-payload-validator"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-rpc-types-engine",
@@ -8448,7 +8447,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "c-kzg",
@@ -8462,7 +8461,7 @@ dependencies = [
 [[package]]
 name = "reth-primitives-traits"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8495,7 +8494,7 @@ dependencies = [
 [[package]]
 name = "reth-provider"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8540,7 +8539,7 @@ dependencies = [
 [[package]]
 name = "reth-prune"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8568,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "reth-prune-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -8582,7 +8581,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-protocol"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8601,7 +8600,7 @@ dependencies = [
 [[package]]
 name = "reth-ress-provider"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -8628,7 +8627,7 @@ dependencies = [
 [[package]]
 name = "reth-revm"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "reth-primitives-traits",
@@ -8641,7 +8640,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8720,7 +8719,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
@@ -8748,7 +8747,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-builder"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -8787,7 +8786,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-convert"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -8808,7 +8807,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-engine-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8838,7 +8837,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -8882,7 +8881,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-eth-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -8929,7 +8928,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-layer"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-rpc-types-engine",
  "http 1.3.1",
@@ -8943,7 +8942,7 @@ dependencies = [
 [[package]]
 name = "reth-rpc-server-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -8959,7 +8958,7 @@ dependencies = [
 [[package]]
 name = "reth-stages"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9003,7 +9002,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9030,7 +9029,7 @@ dependencies = [
 [[package]]
 name = "reth-stages-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "arbitrary",
@@ -9044,7 +9043,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "parking_lot",
@@ -9064,7 +9063,7 @@ dependencies = [
 [[package]]
 name = "reth-static-file-types"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "clap",
@@ -9076,7 +9075,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-api"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9099,7 +9098,7 @@ dependencies = [
 [[package]]
 name = "reth-storage-errors"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -9115,7 +9114,7 @@ dependencies = [
 [[package]]
 name = "reth-tasks"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "auto_impl",
  "dyn-clone",
@@ -9133,7 +9132,7 @@ dependencies = [
 [[package]]
 name = "reth-tokio-util"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -9143,7 +9142,7 @@ dependencies = [
 [[package]]
 name = "reth-tracing"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "clap",
  "eyre",
@@ -9158,7 +9157,7 @@ dependencies = [
 [[package]]
 name = "reth-transaction-pool"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9198,7 +9197,7 @@ dependencies = [
 [[package]]
 name = "reth-trie"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -9223,7 +9222,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-common"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -9249,7 +9248,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-db"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "reth-db-api",
@@ -9262,7 +9261,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-parallel"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9287,7 +9286,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9306,7 +9305,7 @@ dependencies = [
 [[package]]
 name = "reth-trie-sparse-parallel"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -9324,7 +9323,7 @@ dependencies = [
 [[package]]
 name = "reth-zstd-compressors"
 version = "1.8.2"
-source = "git+https://github.com/hl-archive-node/reth?rev=416c2e26756f1c8ee86e6b8e4081f434952b3a1a#416c2e26756f1c8ee86e6b8e4081f434952b3a1a"
+source = "git+https://github.com/hl-archive-node/reth?rev=e57dd1dec65b25353c0002be6a559ac713eb6e64#e57dd1dec65b25353c0002be6a559ac713eb6e64"
 dependencies = [
  "zstd",
 ]
@@ -9419,6 +9418,7 @@ dependencies = [
  "reth-trie-common",
  "reth-trie-db",
  "revm",
+ "revm-inspectors",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -9560,8 +9560,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9b329afcc0f9fd5adfa2c6349a7435a8558e82bcae203142103a9a95e2a63b6"
+source = "git+https://github.com/hl-archive-node/revm-inspectors?rev=065ed2383acbbe85b4c2535bbff3b8b8e68f1a70#065ed2383acbbe85b4c2535bbff3b8b8e68f1a70"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,53 +26,54 @@ lto = "fat"
 codegen-units = 1
 
 [dependencies]
-reth = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-cli = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-cli-commands = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-basic-payload-builder = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-db = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-db-api = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-chainspec = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-cli-util = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-discv4 = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-engine-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-ethereum-forks = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-ethereum-payload-builder = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-ethereum-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-eth-wire = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-eth-wire-types = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-evm = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-evm-ethereum = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-node-core = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-revm = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-network = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-network-p2p = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-network-api = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-node-ethereum = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-network-peers = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-payload-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-primitives-traits = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-provider = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a", features = ["test-utils"] }
-reth-rpc = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-eth-api = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-engine-api = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-tracing = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-trie-common = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-trie-db = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-codecs = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-transaction-pool = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-stages-types = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-storage-api = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-errors = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-convert = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-eth-types = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-server-types = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-metrics = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-builder = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-ipc = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
-reth-rpc-layer = { git = "https://github.com/hl-archive-node/reth", rev = "416c2e26756f1c8ee86e6b8e4081f434952b3a1a" }
+reth = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-cli = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-cli-commands = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-basic-payload-builder = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-db = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-db-api = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-chainspec = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-cli-util = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-discv4 = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-engine-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-ethereum-forks = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-ethereum-payload-builder = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-ethereum-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-eth-wire = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-eth-wire-types = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-evm = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-evm-ethereum = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-node-core = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-revm = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-network = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-network-p2p = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-network-api = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-node-ethereum = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-network-peers = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-payload-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-primitives = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-primitives-traits = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-provider = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64", features = ["test-utils"] }
+reth-rpc = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-eth-api = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-engine-api = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-tracing = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-trie-common = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-trie-db = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-codecs = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-transaction-pool = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-stages-types = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-storage-api = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-errors = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-convert = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-eth-types = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-server-types = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-metrics = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-builder = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-ipc = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
+reth-rpc-layer = { git = "https://github.com/hl-archive-node/reth", rev = "e57dd1dec65b25353c0002be6a559ac713eb6e64" }
 revm = { version = "29.0.1", default-features = false }
+revm-inspectors = "0.30.0"
 
 # alloy dependencies
 alloy-genesis = { version = "1.0.37", default-features = false }
@@ -192,6 +193,8 @@ vergen-git2 = "1.0.5"
 # within the monorepo, so patching it alone pulls in duplicate copies and fails to
 # compile. Drop this block once reth carries the fix.
 [patch.crates-io]
+alloy-evm = { git = "https://github.com/hl-archive-node/alloy-evm", rev = "9223654e84fe9e5c36295907f580cbd598f7e961" }
+revm-inspectors = { git = "https://github.com/hl-archive-node/revm-inspectors", rev = "065ed2383acbbe85b4c2535bbff3b8b8e68f1a70" }
 revm = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-bytecode = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }
 revm-context = { git = "https://github.com/hl-archive-node/revm", rev = "fdf9b16bdd4388a680c97440c6e7f085647ece01" }

--- a/src/node/evm/mod.rs
+++ b/src/node/evm/mod.rs
@@ -29,7 +29,7 @@ mod assembler;
 pub mod config;
 mod executor;
 mod factory;
-mod patch;
+pub(crate) mod patch;
 pub mod receipt_builder;
 
 pub use executor::apply_precompiles;

--- a/src/node/evm/patch.rs
+++ b/src/node/evm/patch.rs
@@ -31,21 +31,48 @@ pub(crate) fn patch_mainnet_after_tx(
     is_system_tx: bool,
     changes: &mut HashMap<Address, Account>,
 ) -> Result<(), BlockExecutionError> {
+    if let Some(address) = mainnet_patch_after_tx_address(block_number, tx_index, is_system_tx) {
+        changes.remove(&address);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn mainnet_patch_after_tx_address(
+    block_number: u64,
+    tx_index: u64,
+    is_system_tx: bool,
+) -> Option<Address> {
     if MAINNET_PATCHES_AFTER_TX.is_empty() {
-        return Ok(());
+        return None;
     }
 
     let first = MAINNET_PATCHES_AFTER_TX.first().unwrap().0;
     let last = MAINNET_PATCHES_AFTER_TX.last().unwrap().0;
     if first > block_number || last < block_number {
-        return Ok(());
+        return None;
     }
 
     for (block_num, idx, is_system, address) in MAINNET_PATCHES_AFTER_TX {
         if block_number == *block_num && tx_index == *idx && is_system_tx == *is_system {
-            changes.remove(address);
+            return Some(*address);
         }
     }
 
-    Ok(())
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selects_phantom_selfdestruct_patch() {
+        assert_eq!(
+            mainnet_patch_after_tx_address(1_514_843, 0, false),
+            Some(address!("0x723e5fbbeed025772a91240fd0956a866a41a603"))
+        );
+        assert_eq!(mainnet_patch_after_tx_address(1_514_843, 1, false), None);
+        assert_eq!(mainnet_patch_after_tx_address(1_514_843, 0, true), None);
+    }
 }

--- a/src/node/rpc/mod.rs
+++ b/src/node/rpc/mod.rs
@@ -1,9 +1,12 @@
 use crate::{
     HlBlock, HlPrimitives,
     chainspec::HlChainSpec,
-    node::{evm::apply_precompiles, types::HlExtras},
+    node::{
+        evm::{apply_precompiles, patch::mainnet_patch_after_tx_address},
+        types::HlExtras,
+    },
 };
-use alloy_consensus::{BlockHeader, transaction::TxHashRef};
+use alloy_consensus::{BlockHeader, Transaction, transaction::TxHashRef};
 use alloy_eips::BlockId;
 use alloy_evm::{Evm, EvmFactory};
 use alloy_network::Ethereum;
@@ -238,6 +241,19 @@ where
     EthApiError: FromEvmError<N::Evm>,
     Rpc: RpcConvert<Primitives = N::Primitives, Error = EthApiError>,
 {
+    fn apply_post_execution_state(
+        &self,
+        tx_info: &TransactionInfo,
+        state: &mut revm::state::EvmState,
+    ) -> Result<(), Self::Error> {
+        if let (Some(block_number), Some(tx_index)) = (tx_info.block_number, tx_info.index) &&
+            let Some(address) = mainnet_patch_after_tx_address(block_number, tx_index, false)
+        {
+            state.remove(&address);
+        }
+        Ok(())
+    }
+
     fn inspect<DB, I>(
         &self,
         db: DB,
@@ -314,19 +330,16 @@ where
             let block_hash = block.hash();
             let block_number = evm_env.block_env.number.saturating_to();
             let base_fee = evm_env.block_env.basefee;
-            let hl_extras =
-                this.get_hl_extras(evm_env.block_env.number.to::<u64>().into()).map_err(
-                    |err: ProviderError| <EthApiError as From<ProviderError>>::from(err),
-                )?;
+            let hl_extras = this
+                .get_hl_extras(evm_env.block_env.number.to::<u64>().into())
+                .map_err(|err: ProviderError| <EthApiError as From<ProviderError>>::from(err))?;
 
             let state = this.state_at_block_id(state_at.into()).await?;
             let mut db =
                 CacheDB::new(StateProviderDatabase::new(StateProviderTraitObjWrapper(&state)));
 
-            let max_transactions = highest_index.map_or_else(
-                || block.body().transaction_count(),
-                |highest| highest as usize + 1,
-            );
+            let max_transactions = highest_index
+                .map_or_else(|| block.body().transaction_count(), |highest| highest as usize + 1);
 
             let mut idx = 0;
             let mut evm = this.evm_config().evm_factory().create_evm_with_inspector(
@@ -338,7 +351,15 @@ where
             let mut tracer = TxTracer::new(evm);
 
             let results = tracer
-                .try_trace_many(block.transactions_recovered().take(max_transactions), |ctx| {
+                .try_trace_many(block.transactions_recovered().take(max_transactions), move |ctx| {
+                    let address = mainnet_patch_after_tx_address(
+                        block_number,
+                        idx,
+                        (*ctx.tx.inner()).gas_price() == Some(0),
+                    );
+                    if let Some(address) = address {
+                        ctx.state.remove(&address);
+                    }
                     let tx_info = TransactionInfo {
                         hash: Some(*ctx.tx.tx_hash()),
                         index: Some(idx),

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -90,6 +90,114 @@ echo "$TRACE_RESULT" | jq -e \
     ' > /dev/null \
     && success "$TITLE" || fail "$TITLE - trace_block missing expected tx hashes"
 
+TITLE="Issue #145 - SELFDESTRUCT trace must match canonical state"
+SELFDESTRUCT_TX=0xf6267312b72427da6b27d3b8e6dd7e30cd5b434ab591f0f9acf6832541ed3fc2
+SELFDESTRUCT_BLOCK=0x171d5b
+SELFDESTRUCT_BLOCK_HASH=0x5fc65d154c09c559cc58f160f482a1ece3df25ba8254dfe9f6c2acabd389a481
+SELFDESTRUCT_SOURCE=0x723e5fbbeed025772a91240fd0956a866a41a603
+SELFDESTRUCT_TARGET=0x9eaf2a89b61eeac97f491f81df0860d3fca6ffde
+CALL_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"debug_traceTransaction\",\"params\":[\"$SELFDESTRUCT_TX\",{\"tracer\":\"callTracer\"}]}" \
+    "$TRACE_RPC_URL")
+echo "$CALL_TRACE" | jq -e \
+    --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result | .. | objects | select(.type? == "SELFDESTRUCT")] |
+        length == 1 and .[0].from == $source and .[0].to == $target and .[0].value == "0x1")' \
+    > /dev/null || fail "$TITLE - callTracer returned $CALL_TRACE"
+
+FLAT_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"debug_traceTransaction\",\"params\":[\"$SELFDESTRUCT_TX\",{\"tracer\":\"flatCallTracer\"}]}" \
+    "$TRACE_RPC_URL")
+echo "$FLAT_TRACE" | jq -e \
+    --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.type == "suicide")] | length == 1) and
+    ([.result[]? | select(.type == "suicide")][0].action ==
+        {"address":$source,"balance":"0x1","refundAddress":$target})' \
+    > /dev/null || fail "$TITLE - flatCallTracer returned $FLAT_TRACE"
+
+MUX_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"debug_traceTransaction\",\"params\":[\"$SELFDESTRUCT_TX\",{\"tracer\":\"muxTracer\",\"tracerConfig\":{\"callTracer\":{},\"flatCallTracer\":{}}}]}" \
+    "$TRACE_RPC_URL")
+echo "$MUX_TRACE" | jq -e \
+    --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result.callTracer | .. | objects | select(.type? == "SELFDESTRUCT")] |
+        length == 1 and .[0].from == $source and .[0].to == $target and .[0].value == "0x1") and
+    ([.result.flatCallTracer[]? | select(.type == "suicide")] |
+        length == 1 and .[0].action == {"address":$source,"balance":"0x1","refundAddress":$target})' \
+    > /dev/null || fail "$TITLE - muxTracer returned $MUX_TRACE"
+
+PARITY_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"trace_replayTransaction\",\"params\":[\"$SELFDESTRUCT_TX\",[\"trace\",\"stateDiff\"]]}" \
+    "$TRACE_RPC_URL")
+echo "$PARITY_TRACE" | jq -e \
+    --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result.trace[]? | select(.type == "suicide")] |
+        length == 1 and .[0].action == {"address":$source,"balance":"0x1","refundAddress":$target}) and
+    (.result.stateDiff[$source] == null) and
+    (.result.stateDiff[$target] != null)' \
+    > /dev/null || fail "$TITLE - trace_replayTransaction returned $PARITY_TRACE"
+
+TRANSACTION_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"trace_transaction\",\"params\":[\"$SELFDESTRUCT_TX\"]}" \
+    "$TRACE_RPC_URL")
+echo "$TRANSACTION_TRACE" | jq -e \
+    --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.type == "suicide")] |
+        length == 1 and .[0].action == {"address":$source,"balance":"0x1","refundAddress":$target})' \
+    > /dev/null || fail "$TITLE - trace_transaction returned $TRANSACTION_TRACE"
+
+BLOCK_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"trace_block\",\"params\":[\"$SELFDESTRUCT_BLOCK\"]}" \
+    "$TRACE_RPC_URL")
+echo "$BLOCK_TRACE" | jq -e \
+    --arg tx "$SELFDESTRUCT_TX" --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.transactionHash == $tx and .type == "suicide")] |
+        length == 1 and .[0].action == {"address":$source,"balance":"0x1","refundAddress":$target})' \
+    > /dev/null || fail "$TITLE - trace_block returned $BLOCK_TRACE"
+
+REPLAY_BLOCK_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"trace_replayBlockTransactions\",\"params\":[\"$SELFDESTRUCT_BLOCK\",[\"trace\",\"stateDiff\"]]}" \
+    "$TRACE_RPC_URL")
+echo "$REPLAY_BLOCK_TRACE" | jq -e \
+    --arg tx "$SELFDESTRUCT_TX" --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.transactionHash == $tx)] |
+        length == 1 and
+        ([.[0].trace[]? | select(.type == "suicide")] |
+            length == 1 and .[0].action == {"address":$source,"balance":"0x1","refundAddress":$target}) and
+        .[0].stateDiff[$source] == null and
+        .[0].stateDiff[$target] != null)' \
+    > /dev/null || fail "$TITLE - trace_replayBlockTransactions returned $REPLAY_BLOCK_TRACE"
+
+DEBUG_BLOCK_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"debug_traceBlockByNumber\",\"params\":[\"$SELFDESTRUCT_BLOCK\",{\"tracer\":\"callTracer\"}]}" \
+    "$TRACE_RPC_URL")
+echo "$DEBUG_BLOCK_TRACE" | jq -e \
+    --arg tx "$SELFDESTRUCT_TX" --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.txHash == $tx).result | .. | objects |
+        select(.type? == "SELFDESTRUCT")] |
+        length == 1 and .[0].from == $source and .[0].to == $target and .[0].value == "0x1")' \
+    > /dev/null || fail "$TITLE - debug_traceBlockByNumber returned $DEBUG_BLOCK_TRACE"
+
+DEBUG_BLOCK_HASH_TRACE=$(curl -sS -H 'content-type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"debug_traceBlockByHash\",\"params\":[\"$SELFDESTRUCT_BLOCK_HASH\",{\"tracer\":\"callTracer\"}]}" \
+    "$TRACE_RPC_URL")
+echo "$DEBUG_BLOCK_HASH_TRACE" | jq -e \
+    --arg tx "$SELFDESTRUCT_TX" --arg source "$SELFDESTRUCT_SOURCE" --arg target "$SELFDESTRUCT_TARGET" \
+    '(.error | not) and
+    ([.result[]? | select(.txHash == $tx).result | .. | objects |
+        select(.type? == "SELFDESTRUCT")] |
+        length == 1 and .[0].from == $source and .[0].to == $target and .[0].value == "0x1")' \
+    > /dev/null || fail "$TITLE - debug_traceBlockByHash returned $DEBUG_BLOCK_HASH_TRACE"
+success "$TITLE"
+
 TITLE="Issue #143 - unknown/unavailable blocks must return null instead of panicking"
 UNKNOWN_HASH=0x1111111111111111111111111111111111111111111111111111111111111111
 FUTURE_BLOCK=0x7fffffffff


### PR DESCRIPTION
## Summary

- apply Hyperliquid post-transaction patches during block trace replay before state is committed
- reconcile tracing inspector metadata and parity state diffs with canonical patched state
- pin reth and alloy-evm forks that expose the required chain-specific tracing hooks

## Regression

Transaction `0xf6267312b72427da6b27d3b8e6dd7e30cd5b434ab591f0f9acf6832541ed3fc2` at block `1514843` no longer reports a phantom SELFDESTRUCT through either `debug_traceTransaction` or `trace_replayTransaction`.

## Dependencies

- `hl-archive-node/reth@c9983dbb377a63e4bddd24dc78533b0a72b115d4`
- `hl-archive-node/alloy-evm@9223654e84fe9e5c36295907f580cbd598f7e961`

## Validation

- `cargo check --locked --bin reth-hl`
- `cargo test --locked selects_phantom_selfdestruct_patch --lib`
- `make install`