### PR TITLE
fix: register pseudo peer as trusted on main node

### DIFF
--- a/src/node/network/mod.rs
+++ b/src/node/network/mod.rs
@@ -257,6 +257,7 @@ where
             pool,
         );
         let local_node_record = handle.local_node_record();
+        let destination_network = handle.clone();
         info!(target: "reth::cli", enode=%local_node_record, "P2P networking initialized");
 
         if let Some(block_source_config) = block_source_config {
@@ -312,7 +313,7 @@ where
 
                 start_pseudo_peer(
                     chain_spec.clone(),
-                    local_node_record.to_string(),
+                    destination_network,
                     block_store,
                     debug_cutoff_height,
                 )

--- a/src/pseudo_peer/mod.rs
+++ b/src/pseudo_peer/mod.rs
@@ -33,31 +33,34 @@ pub mod prelude {
     };
 }
 
-use crate::chainspec::HlChainSpec;
-use reth_discv4::NodeRecord;
-use reth_network::{NetworkEvent, NetworkEventListenerProvider};
-use reth_network_api::Peers;
-use std::str::FromStr;
+use crate::{chainspec::HlChainSpec, node::network::HlNetworkPrimitives};
+use reth_network::{NetworkEvent, NetworkEventListenerProvider, NetworkHandle};
+use reth_network_api::{Peers, PeersInfo};
+
+fn configure_pseudo_peer_connection(
+    pseudo_peer: &NetworkHandle<HlNetworkPrimitives>,
+    destination: &NetworkHandle<HlNetworkPrimitives>,
+) {
+    // The destination sees this as an inbound connection. Register it up front so adaptive
+    // request timeouts cannot lower the pseudo peer's reputation until it is banned.
+    let pseudo_peer_record = pseudo_peer.local_node_record();
+    destination.add_trusted_peer(pseudo_peer_record.id, pseudo_peer_record.tcp_addr());
+
+    let destination_record = destination.local_node_record();
+    pseudo_peer.add_trusted_peer(destination_record.id, destination_record.tcp_addr());
+}
 
 /// Main function that starts the network manager and processes eth requests
 pub async fn start_pseudo_peer(
     chain_spec: Arc<HlChainSpec>,
-    destination_peer: String,
+    destination_network: NetworkHandle<HlNetworkPrimitives>,
     block_store: Arc<BlockStore>,
     debug_cutoff_height: Option<u64>,
 ) -> eyre::Result<()> {
-
-    // Parse the destination peer enode string
-    let node_record = NodeRecord::from_str(&destination_peer)
-        .map_err(|e| eyre::eyre!("Failed to parse destination peer: {e}"))?;
-
     // Create network manager (no boot_nodes — we add the peer directly)
-    let (mut network, start_tx) = create_network_manager(
-        (*chain_spec).clone(),
-        block_store.clone(),
-        debug_cutoff_height,
-    )
-    .await?;
+    let (mut network, start_tx) =
+        create_network_manager((*chain_spec).clone(), block_store.clone(), debug_cutoff_height)
+            .await?;
 
     // Create the channels for receiving eth messages
     let (eth_tx, mut eth_rx) = mpsc::channel(32);
@@ -74,12 +77,13 @@ pub async fn start_pseudo_peer(
     tokio::spawn(network);
 
     // Directly add the main node as a peer (bypasses discovery)
+    let node_record = destination_network.local_node_record();
     info!(
         peer_id = %node_record.id,
         addr = %node_record.tcp_addr(),
         "Adding main node as direct peer"
     );
-    network_handle.add_trusted_peer(node_record.id, node_record.tcp_addr());
+    configure_pseudo_peer_connection(&network_handle, &destination_network);
 
     let mut first = true;
 
@@ -104,5 +108,68 @@ pub async fn start_pseudo_peer(
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reth_network_api::{
+        PeerKind,
+        events::{NetworkPeersEvents, PeerEvent, PeerEventStream},
+    };
+    use std::{path::Path, time::Duration};
+    use tempfile::TempDir;
+    use tokio_stream::StreamExt;
+
+    fn local_store(path: &Path) -> Arc<BlockStore> {
+        let source: BlockSourceBoxed =
+            Arc::new(Box::new(LocalBlockSource::new(path.to_path_buf())));
+        Arc::new(BlockStore::new(source, None, 998))
+    }
+
+    async fn active_peer_kind(events: &mut PeerEventStream) -> PeerKind {
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(PeerEvent::SessionEstablished(info)) = events.next().await {
+                    return info.peer_kind;
+                }
+            }
+        })
+        .await
+        .expect("networks should connect")
+    }
+
+    #[tokio::test]
+    async fn pseudo_peer_is_trusted_by_main_node() {
+        let pseudo_dir = TempDir::new().unwrap();
+        let destination_dir = TempDir::new().unwrap();
+        let (pseudo_network, _) =
+            create_network_manager(HlChainSpec::default(), local_store(pseudo_dir.path()), None)
+                .await
+                .unwrap();
+        let (destination_network, _) = create_network_manager(
+            HlChainSpec::default(),
+            local_store(destination_dir.path()),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let pseudo_handle = pseudo_network.handle().clone();
+        let destination_handle = destination_network.handle().clone();
+        let mut pseudo_events = pseudo_handle.peer_events();
+        let mut destination_events = destination_handle.peer_events();
+
+        configure_pseudo_peer_connection(&pseudo_handle, &destination_handle);
+        tokio::spawn(pseudo_network);
+        tokio::spawn(destination_network);
+
+        let (pseudo_kind, destination_kind) = tokio::join!(
+            active_peer_kind(&mut pseudo_events),
+            active_peer_kind(&mut destination_events)
+        );
+        assert_eq!(pseudo_kind, PeerKind::Trusted);
+        assert_eq!(destination_kind, PeerKind::Trusted);
     }
 }


### PR DESCRIPTION
## Summary
- pass the main node network handle into the pseudo-peer startup path
- register both sides as trusted before establishing the localhost session
- add an integration regression test that starts two real network managers and asserts both session directions are `Trusted`

## Root cause
The pseudo peer registered the main node as trusted, but the main node accepted the pseudo peer as an inbound `Basic` peer. Adaptive request timeouts during large S3-backed header sync therefore accumulated negative reputation until the main node banned the pseudo peer. From then on, each reconnect was immediately disconnected; restarting only reset the in-memory ban temporarily.

## Validation
- regression test before fix: `Basic != Trusted` on the main-node side
- regression test after fix: both sides are `Trusted`
- `cargo test --lib --no-default-features`: 19 passed
- `git diff --check`